### PR TITLE
Shots

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ Assuming you have Poetry installed
 
 With plain pip:
 - `pip install --index-url https://ea3a0fbb-599f-4d83-86f1-0e71abe27513.ka.bw-cloud-instance.org/lc3267/quantum/+simple/ qml-essentials`
+
+## Contributing
+
+Building and packaging requires some extra steps (assuming Poetry):
+- `poetry run devpi use https://ea3a0fbb-599f-4d83-86f1-0e71abe27513.ka.bw-cloud-instance.org`
+- `poetry run devpi login alice --password=456`
+- `poetry run devpi use alice/quantum`
+- `poetry config repositories.foo https://ea3a0fbb-599f-4d83-86f1-0e71abe27513.ka.bw-cloud-instance.org/lc3267/quantum`
+- `poetry config http-basic.foo alice 456` (or remove password for interactive prompt)
+- `poetry publish --build -r foo`

--- a/poetry.lock
+++ b/poetry.lock
@@ -594,6 +594,26 @@ files = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.2.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343"},
+    {file = "pytest-8.2.2.tar.gz", hash = "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2.0"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -806,4 +826,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f641310ca86dec47fada2f083ebc93c711bbcdabd516b2e4501fb5be3a6bf876"
+content-hash = "00ce438bdd4de0a0b94ad6e593aef82e927e8065ba3a3d6ec03b8eede9b8e447"

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,6 +42,50 @@ docs = ["astroid (<3)", "furo", "ipython (!=8.7.0)", "myst-nb", "setuptools-scm"
 tests = ["coverage", "numpy", "pytest", "pytest-cov"]
 
 [[package]]
+name = "black"
+version = "24.4.2"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "black-24.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce"},
+    {file = "black-24.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021"},
+    {file = "black-24.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063"},
+    {file = "black-24.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96"},
+    {file = "black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474"},
+    {file = "black-24.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c"},
+    {file = "black-24.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb"},
+    {file = "black-24.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1"},
+    {file = "black-24.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d"},
+    {file = "black-24.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04"},
+    {file = "black-24.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc"},
+    {file = "black-24.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0"},
+    {file = "black-24.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7"},
+    {file = "black-24.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94"},
+    {file = "black-24.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8"},
+    {file = "black-24.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c"},
+    {file = "black-24.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1"},
+    {file = "black-24.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741"},
+    {file = "black-24.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"},
+    {file = "black-24.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7"},
+    {file = "black-24.4.2-py3-none-any.whl", hash = "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c"},
+    {file = "black-24.4.2.tar.gz", hash = "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "build"
 version = "1.2.1"
 description = "A simple, correct Python build frontend"
@@ -204,6 +248,20 @@ setuptools = "*"
 test = ["mock (>=3.0.0)", "pytest"]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -300,6 +358,17 @@ docs = ["sphinx (==5.3.0)", "sphinx-rtd-theme (==1.0.0)"]
 mypy = ["mypy"]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "networkx"
 version = "3.3"
 description = "Python package for creating and manipulating graphs and networks"
@@ -386,6 +455,17 @@ files = [
 
 [package.dependencies]
 packaging = ">=23.0"
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
 
 [[package]]
 name = "pennylane"
@@ -726,4 +806,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ac1a140a6f96f1e0e412ac71bbafbde90ffb74c403cdc81908958aabb13e93e4"
+content-hash = "f641310ca86dec47fada2f083ebc93c711bbcdabd516b2e4501fb5be3a6bf876"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ pennylane = "^0.36.0"
 
 [tool.poetry.group.dev.dependencies]
 devpi-client = "^7.0.3"
+black = "^24.4.2"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,3 @@ black = "^24.4.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.black]
-line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.3"
+version = "0.1.5"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pennylane = "^0.36.0"
 [tool.poetry.group.dev.dependencies]
 devpi-client = "^7.0.3"
 black = "^24.4.2"
+pytest = "^8.2.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.5"
+version = "0.1.8"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -38,7 +38,9 @@ class Circuit(ABC):
         """
         return
 
-    def get_control_angles(self, w: np.ndarray, n_qubits: int) -> Optional[np.ndarray]:
+    def get_control_angles(
+        self, w: np.ndarray, n_qubits: int
+    ) -> Optional[np.ndarray]:
         """
         Returns the angles for the controlled rotation gates from the list of
         all parameters for one layer.
@@ -157,7 +159,8 @@ class Ansaetze:
             if n_qubits > 1:
                 for q in range(n_qubits):
                     qml.CRX(
-                        w[w_idx], wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits]
+                        w[w_idx],
+                        wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits],
                     )
                     w_idx += 1
 
@@ -199,7 +202,8 @@ class Ansaetze:
             if n_qubits > 1:
                 for q in range(n_qubits):
                     qml.CRZ(
-                        w[w_idx], wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits]
+                        w[w_idx],
+                        wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits],
                     )
                     w_idx += 1
 
@@ -237,7 +241,9 @@ class Ansaetze:
 
             if n_qubits > 1:
                 for q in range(n_qubits):
-                    qml.CNOT(wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits])
+                    qml.CNOT(
+                        wires=[n_qubits - q - 1, (n_qubits - q) % n_qubits]
+                    )
 
             for q in range(n_qubits):
                 qml.RZ(w[w_idx], wires=q)

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -57,7 +57,7 @@ class Model:
         self.output_qubit: int = output_qubit
 
         # Initialize ansatz
-        self._pqc: Callable[[Optional[np.ndarray], int], int] = getattr(
+        self.pqc: Callable[[Optional[np.ndarray], int], int] = getattr(
             Ansaetze, circuit_type or "no_ansatz"
         )()
 
@@ -74,11 +74,11 @@ class Model:
 
         params_shape: Tuple[int, int] = (
             impl_n_layers,
-            self._pqc.n_params_per_layer(self.n_qubits),
+            self.pqc.n_params_per_layer(self.n_qubits),
         )
 
         def set_control_params(params, value):
-            indices = self._pqc.get_control_indices(self.n_qubits)
+            indices = self.pqc.get_control_indices(self.n_qubits)
             if indices is None:
                 warnings.warn(
                     f"Specified {initialization} but circuit\
@@ -237,7 +237,7 @@ class Model:
         """
 
         for l in range(0, self.n_layers):
-            self._pqc(params[l], self.n_qubits)
+            self.pqc(params[l], self.n_qubits)
 
             if self.data_reupload or l == 0:
                 self._iec(inputs, data_reupload=self.data_reupload)
@@ -258,7 +258,7 @@ class Model:
                     )
 
         if self.data_reupload:
-            self._pqc(params[-1], self.n_qubits)
+            self.pqc(params[-1], self.n_qubits)
 
         # run mixed simualtion and get density matrix
         if self.execution_type == "density":
@@ -349,7 +349,7 @@ class Model:
                 {
                     "n_qubits": self.n_qubits,
                     "n_layers": self.n_layers,
-                    "pqc": self._pqc.__class__.__name__,
+                    "pqc": self.pqc.__class__.__name__,
                     "dru": self.data_reupload,
                     "params": params,
                     "noise_params": self.noise_params,

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -125,11 +125,27 @@ class Model:
             None
         """
         if inputs is None:
-            inputs = [0]
+            # initialize to zero
+            inputs = np.array([[0]])
+        elif len(inputs.shape) == 1:
+            # add a batch dimension
+            inputs = np.array([inputs])
 
         if data_reupload:
-            for q in range(self.n_qubits):
-                qml.RX(inputs, wires=q)
+            if inputs.shape[1] == 1:
+                for q in range(self.n_qubits):
+                    qml.RX(inputs[:, 0], wires=q)
+            elif inputs.shape[1] == 2:
+                for q in range(self.n_qubits):
+                    qml.RX(inputs[:, 0], wires=q)
+                    qml.RY(inputs[:, 1], wires=q)
+            elif inputs.shape[1] == 3:
+                for q in range(self.n_qubits):
+                    qml.Rot(inputs[:, 0], inputs[:, 1], inputs[:, 2], wires=q)
+            else:
+                raise ValueError(
+                    "The number of parameters for this IEC cannot be greater than 3"
+                )
         else:
             qml.RX(inputs, wires=0)
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -306,8 +306,8 @@ class Model:
             np.ndarray: The output of the quantum circuit.
 
         Raises:
-            NotImplementedError: If the number of shots is not None or if the expectation
-                value is True.
+            NotImplementedError: If the number of shots is not None or if the
+                expectation value is True.
         """
         # set the parameters as object attributes
         self.noise_params = noise_params

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -82,7 +82,7 @@ class Model:
             if indices is None:
                 warnings.warn(
                     f"Specified {initialization} but circuit\
-                    does not contain controlled rotation gates.
+                    does not contain controlled rotation gates.\
                     Parameters are intialized randomly.",
                     UserWarning,
                 )
@@ -360,10 +360,6 @@ class Model:
 
         result: Optional[np.ndarray] = None
         if cache:
-            if self.shots is not None or self.exp_val:
-                raise NotImplementedError(
-                    "Caching with shots or exp_val not yet implemented."
-                )
             name: str = f"pqc_{hs}.npy"
 
             cache_folder: str = ".cache"

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -66,7 +66,9 @@ class Model:
         self.shots = None if shots <= 0 else shots
 
         if data_reupload:
-            impl_n_layers: int = n_layers + 1  # we need L+1 according to Schuld et al.
+            impl_n_layers: int = (
+                n_layers + 1
+            )  # we need L+1 according to Schuld et al.
             self.degree = n_layers * n_qubits
         else:
             impl_n_layers: int = n_layers
@@ -87,7 +89,9 @@ class Model:
                 )
             else:
                 params[:, indices[0] : indices[1] : indices[2]] = (
-                    np.ones_like(params[:, indices[0] : indices[1] : indices[2]])
+                    np.ones_like(
+                        params[:, indices[0] : indices[1] : indices[2]]
+                    )
                     * value
                 )
             return params
@@ -97,7 +101,9 @@ class Model:
                 0, 2 * np.pi, params_shape, requires_grad=True
             )
         elif initialization == "zeros":
-            self.params: np.ndarray = np.zeros(params_shape, requires_grad=True)
+            self.params: np.ndarray = np.zeros(
+                params_shape, requires_grad=True
+            )
         elif initialization == "zero-controlled":
             self.params: np.ndarray = np.random.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True
@@ -112,11 +118,14 @@ class Model:
             raise Exception("Invalid initialization method")
 
         log.info(
-            f"Initialized parameters with shape {self.params.shape} using strategy {initialization}."
+            f"Initialized parameters with shape {self.params.shape}\
+            using strategy {initialization}."
         )
 
         device = "default.mixed" if self.shots is None else "default.qubit"
-        self.dev: qml.Device = qml.device(device, shots=self.shots, wires=self.n_qubits)
+        self.dev: qml.Device = qml.device(
+            device, shots=self.shots, wires=self.n_qubits
+        )
 
         log.info(f"Using device {device}.")
 
@@ -134,8 +143,8 @@ class Model:
 
         Args:
             inputs (np.ndarray): length of vector must be 1, shape (1,)
-            data_reupload (bool, optional): Whether to reupload the data for the IEC
-                or not, default is True.
+            data_reupload (bool, optional): Whether to reupload the data
+                for the IEC or not, default is True.
 
         Returns:
             None
@@ -174,16 +183,18 @@ class Model:
         Creates a circuit with noise.
 
         Args:
-            params (np.ndarray): weight vector of shape [n_layers, n_qubits*n_params_per_layer]
+            params (np.ndarray): weight vector of shape
+                [n_layers, n_qubits*n_params_per_layer]
             inputs (np.ndarray): input vector of size 1
         Returns:
-            Union[float, np.ndarray]: Expectation value of PauliZ(0) of the circuit if
-                state_vector is False and exp_val is True, otherwise the density matrix
-                of all qubits.
+            Union[float, np.ndarray]: Expectation value of PauliZ(0)
+                of the circuit if state_vector is False and exp_val is True,
+                otherwise the density matrix of all qubits.
 
         Raises:
-            ValueError: If a) state_vector and exp_val are set, b) if either state_vector or
-            exp_val is true and shots is not none, c) if state_vector and exp_val are both false
+            ValueError: If a) state_vector and exp_val are set,
+            b) if either state_vector or exp_val is true and shots is not none,
+            c) if state_vector and exp_val are both false
             but shots_is none
         """
 
@@ -196,7 +207,9 @@ class Model:
             if self.noise_params is not None:
                 for q in range(self.n_qubits):
                     qml.BitFlip(self.noise_params.get("BitFlip", 0.0), wires=q)
-                    qml.PhaseFlip(self.noise_params.get("PhaseFlip", 0.0), wires=q)
+                    qml.PhaseFlip(
+                        self.noise_params.get("PhaseFlip", 0.0), wires=q
+                    )
                     qml.AmplitudeDamping(
                         self.noise_params.get("AmplitudeDamping", 0.0), wires=q
                     )
@@ -204,7 +217,8 @@ class Model:
                         self.noise_params.get("PhaseDamping", 0.0), wires=q
                     )
                     qml.DepolarizingChannel(
-                        self.noise_params.get("DepolarizingChannel", 0.0), wires=q
+                        self.noise_params.get("DepolarizingChannel", 0.0),
+                        wires=q,
                     )
 
         if self.data_reupload:
@@ -221,7 +235,7 @@ class Model:
                 return 2 * qml.probs(wires=self.output_qubit) - 1
         else:
             raise ValueError(
-                f"Invalid combination of parameters state_vector:{self.state_vector}, 
+                f"Invalid combination of parameters state_vector:{self.state_vector},\
                 exp_val:{self.exp_val} and shots:{self.shots}"
             )
 
@@ -248,16 +262,21 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of size n_layers*(n_qubits*3-1).
             inputs (np.ndarray): Input vector of size 1.
-            noise_params (Optional[Dict[str, float]], optional): Dictionary with noise parameters. Defaults to None.
+            noise_params (Optional[Dict[str, float]], optional):
+                Dictionary with noise parameters. Defaults to None.
             cache (Optional[bool], optional): Cache the circuit. Defaults to False.
-            state_vector (bool, optional): Measure the state vector instead of the wave function. Defaults to False.
-            exp_val (bool, optional): Compute the expectation value of PauliZ(0). Defaults to True.
+            state_vector (bool, optional): Measure the state vector
+                instead of the wave function. Defaults to False.
+            exp_val (bool, optional): Compute the expectation value of PauliZ(0).
+                Defaults to True.
 
         Returns:
             np.ndarray: Expectation value of PauliZ(0) of the circuit.
         """
         # Call forward method which handles the actual caching etc.
-        return self._forward(params, inputs, noise_params, cache, state_vector, exp_val)
+        return self._forward(
+            params, inputs, noise_params, cache, state_vector, exp_val
+        )
 
     def _forward(
         self,
@@ -274,12 +293,14 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of size n_layers*(n_qubits*3-1).
             inputs (np.ndarray): Input vector of size 1.
-            noise_params (Optional[Dict[str, float]], optional): The noise parameters.
-                Defaults to None.
-            cache (Optional[bool], optional): Whether to cache the results. Defaults to False.
-            state_vector (bool, optional): Whether to return the state vector instead of the
-                expectation value. Defaults to False.
-            exp_val (bool, optional): Whether to compute the expectation value. Defaults to True.
+            noise_params (Optional[Dict[str, float]], optional):
+                The noise parameters. Defaults to None.
+            cache (Optional[bool], optional): Whether to cache the results.
+                Defaults to False.
+            state_vector (bool, optional): Whether to return the state vector
+                instead of the expectation value. Defaults to False.
+            exp_val (bool, optional): Whether to compute the expectation value.
+                Defaults to True.
 
         Returns:
             np.ndarray: The output of the quantum circuit.

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -24,6 +24,7 @@ class Model:
         data_reupload: bool = True,
         initialization: str = "random",
         output_qubit: int = 0,
+        shots: Optional[int] = None,
     ) -> None:
         """
         Initialize the quantum circuit model.
@@ -52,6 +53,9 @@ class Model:
         )()
 
         log.info(f"Using {circuit_type} circuit.")
+
+        # Only reasonable number of shots
+        self.shots = None if shots <= 0 else shots
 
         if data_reupload:
             impl_n_layers: int = n_layers + 1  # we need L+1 according to Schuld et al.
@@ -97,12 +101,10 @@ class Model:
         else:
             raise Exception("Invalid initialization method")
 
-        # Initialize default parameters needed for circuit evaluation
-        self.noise_params: Optional[Dict[str, float]] = None
-        self.state_vector: bool = False
-        self.exp_val: bool = True
 
-        self.dev: qml.Device = qml.device("default.mixed", wires=n_qubits)
+        device = "default.mixed" if self.shots is None else "default.qubit"
+        self.dev: qml.Device = qml.device(device, shots=self.shots, wires=self.n_qubits)
+
 
         self.circuit: qml.QNode = qml.QNode(self._circuit, self.dev)
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -217,7 +217,17 @@ class Model:
                     "The number of parameters for this IEC cannot be greater than 3"
                 )
         else:
-            qml.RX(inputs, wires=0)
+            if inputs.shape[1] == 1:
+                qml.RX(inputs[:, 0], wires=0)
+            elif inputs.shape[1] == 2:
+                qml.RX(inputs[:, 0], wires=0)
+                qml.RY(inputs[:, 1], wires=0)
+            elif inputs.shape[1] == 3:
+                qml.Rot(inputs[:, 0], inputs[:, 1], inputs[:, 2], wires=0)
+            else:
+                raise ValueError(
+                    "The number of parameters for this IEC cannot be greater than 3"
+                )
 
     def _circuit(
         self,
@@ -276,8 +286,8 @@ class Model:
         else:
             raise ValueError(f"Invalid execution_type: {self.execution_type}.")
 
-    def _draw(self) -> None:
-        result = qml.draw(self.circuit)(params=self.params, inputs=None)
+    def _draw(self, inputs=None) -> None:
+        result = qml.draw(self.circuit)(params=self.params, inputs=inputs)
         return result
 
     def __repr__(self) -> str:

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -314,7 +314,8 @@ class Model:
                 - If execution_type is 'expval', returns an ndarray of shape (1,).
                 - If execution_type is 'density', returns an ndarray
                     of shape (2**n_qubits, 2**n_qubits).
-                - If execution_type is 'probs', returns an ndarray of shape (2**n_qubits,).
+                - If execution_type is 'probs', returns an ndarray
+                    of shape (2**n_qubits,).
         """
         # Call forward method which handles the actual caching etc.
         return self._forward(params, inputs, noise_params, cache, execution_type)
@@ -347,7 +348,8 @@ class Model:
                 - If execution_type is 'expval', returns an ndarray of shape (1,).
                 - If execution_type is 'density', returns an ndarray
                     of shape (2**n_qubits, 2**n_qubits).
-                - If execution_type is 'probs', returns an ndarray of shape (2**n_qubits,).
+                - If execution_type is 'probs', returns an ndarray
+                    of shape (2**n_qubits,).
 
         Raises:
             NotImplementedError: If the number of shots is not None or if the

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -242,7 +242,14 @@ class Model:
             )
 
     def _draw(self) -> None:
-        return qml.draw(self.circuit)(params=self.params, inputs=None)
+        tmp_state_vector = self.state_vector
+        tmp_exp_val = self.exp_val
+        self.state_vector = False
+        self.exp_val = True
+        result = qml.draw(self.circuit)(params=self.params, inputs=None)
+        self.state_vector = tmp_state_vector
+        self.exp_val = tmp_exp_val
+        return result
 
     def __repr__(self) -> str:
         return self._draw()

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -386,10 +386,6 @@ class Model:
                     inputs=inputs,
                 )
 
-            # probabilities were used -> convert to expectation values
-            if self.execution_type == "probs":
-                result = 2 * result - 1
-
         if cache:
             np.save(file_path, result)
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -45,8 +45,8 @@ class Model:
                 Can be "random", "zeros", "zero-controlled", or "pi-controlled".
                 Defaults to "random".
             output_qubit (int, optional): The index of the output qubit.
-            shots (Optional[int], optional): The number of shots to use for the quantum device.
-                Defaults to None.
+            shots (Optional[int], optional): The number of shots to use for
+                the quantum device. Defaults to None.
 
         Returns:
             None
@@ -123,7 +123,8 @@ class Model:
             using strategy {initialization}."
         )
 
-        # Initialize two circuits, one with the default device and one with the mixed device
+        # Initialize two circuits, one with the default device and
+        # one with the mixed device
         # which allows us to later route depending on the state_vector flag
         self.circuit: qml.QNode = qml.QNode(
             self._circuit,
@@ -293,21 +294,26 @@ class Model:
         cache: Optional[bool] = False,
         execution_type: str = "expval",
     ) -> np.ndarray:
-        """Perform a forward pass of the quantum circuit.
+        """
+        Perform a forward pass of the quantum circuit.
 
         Args:
-            params (np.ndarray): Weight vector of size n_layers*(n_qubits*3-1).
-            inputs (np.ndarray): Input vector of size 1.
-            noise_params (Optional[Dict[str, float]], optional):
-                Dictionary with noise parameters. Defaults to None.
-            cache (Optional[bool], optional): Cache the circuit. Defaults to False.
-            execution_type (str, optional): The type of execution. Must be one of 'expval', 'density', or 'probs'.
-                Defaults to 'expval'.
+            params (np.ndarray): Weight vector of shape
+                [n_layers, n_qubits*n_params_per_layer].
+            inputs (np.ndarray): Input vector of shape [1].
+            noise_params (Optional[Dict[str, float]], optional): The noise parameters.
+                Defaults to None.
+            cache (Optional[bool], optional): Whether to cache the results.
+                Defaults to False.
+            execution_type (str, optional): The type of execution.
+                Must be one of 'expval', 'density', or 'probs'. Defaults to 'expval'.
 
         Returns:
-            np.ndarray: The output of the quantum circuit. The shape depends on the execution_type.
+            np.ndarray: The output of the quantum circuit.
+                The shape depends on the execution_type.
                 - If execution_type is 'expval', returns an ndarray of shape (1,).
-                - If execution_type is 'density', returns an ndarray of shape (2**n_qubits, 2**n_qubits).
+                - If execution_type is 'density', returns an ndarray
+                    of shape (2**n_qubits, 2**n_qubits).
                 - If execution_type is 'probs', returns an ndarray of shape (2**n_qubits,).
         """
         # Call forward method which handles the actual caching etc.
@@ -325,16 +331,22 @@ class Model:
         Perform a forward pass of the quantum circuit.
 
         Args:
-            params (np.ndarray): Weight vector of shape [n_layers, n_qubits*n_params_per_layer].
+            params (np.ndarray): Weight vector of shape
+                [n_layers, n_qubits*n_params_per_layer].
             inputs (np.ndarray): Input vector of shape [1].
-            noise_params (Optional[Dict[str, float]], optional): The noise parameters. Defaults to None.
-            cache (Optional[bool], optional): Whether to cache the results. Defaults to False.
-            execution_type (str, optional): The type of execution. Must be one of 'expval', 'density', or 'probs'. Defaults to 'expval'.
+            noise_params (Optional[Dict[str, float]], optional): The noise parameters.
+                Defaults to None.
+            cache (Optional[bool], optional): Whether to cache the results.
+                Defaults to False.
+            execution_type (str, optional): The type of execution.
+                Must be one of 'expval', 'density', or 'probs'. Defaults to 'expval'.
 
         Returns:
-            np.ndarray: The output of the quantum circuit. The shape depends on the execution_type.
+            np.ndarray: The output of the quantum circuit.
+                The shape depends on the execution_type.
                 - If execution_type is 'expval', returns an ndarray of shape (1,).
-                - If execution_type is 'density', returns an ndarray of shape (2**n_qubits, 2**n_qubits).
+                - If execution_type is 'density', returns an ndarray
+                    of shape (2**n_qubits, 2**n_qubits).
                 - If execution_type is 'probs', returns an ndarray of shape (2**n_qubits,).
 
         Raises:

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -172,29 +172,19 @@ class Model:
     ) -> Union[float, np.ndarray]:
         """
         Creates a circuit with noise.
-        This involves, Bit Flip, Phase Flip, Amplitude Damping,
-        Phase Damping and Depolarization.
-        The Circuit consists of a PQC and IEC in each layer
-        with the PQC as specified in the construction of the model.
 
         Args:
             params (np.ndarray): weight vector of shape [n_layers, n_qubits*n_params_per_layer]
             inputs (np.ndarray): input vector of size 1
-            noise_params (Optional[Dict[str, float]]): dictionary with noise parameters
-                - "BitFlip": float, default = 0.0
-                - "PhaseFlip": float, default = 0.0
-                - "AmplitudeDamping": float, default = 0.0
-                - "PhaseDamping": float, default = 0.0
-                - "DepolarizingChannel": float, default = 0.0
-            state_vector (bool, optional): Whether to measure the state vector
-                instead of the wave function. Defaults to False.
-            exp_val (bool, optional): Whether to measure the expectation value
-                of PauliZ(0) of the circuit. Defaults to True.
-
         Returns:
             Union[float, np.ndarray]: Expectation value of PauliZ(0) of the circuit if
                 state_vector is False and exp_val is True, otherwise the density matrix
                 of all qubits.
+
+        Raises:
+            ValueError: If a) state_vector and exp_val are set, b) if either state_vector or
+            exp_val is true and shots is not none, c) if state_vector and exp_val are both false
+            but shots_is none
         """
 
         for l in range(0, self.n_layers):
@@ -278,7 +268,8 @@ class Model:
         state_vector: bool = False,
         exp_val: bool = True,
     ) -> np.ndarray:
-        """Perform a forward pass of the quantum circuit.
+        """
+        Perform a forward pass of the quantum circuit.
 
         Args:
             params (np.ndarray): Weight vector of size n_layers*(n_qubits*3-1).
@@ -288,9 +279,14 @@ class Model:
             cache (Optional[bool], optional): Whether to cache the results. Defaults to False.
             state_vector (bool, optional): Whether to return the state vector instead of the
                 expectation value. Defaults to False.
+            exp_val (bool, optional): Whether to compute the expectation value. Defaults to True.
 
         Returns:
             np.ndarray: The output of the quantum circuit.
+
+        Raises:
+            NotImplementedError: If the number of shots is not None or if the expectation
+                value is True.
         """
         # set the parameters as object attributes
         self.noise_params = noise_params
@@ -311,19 +307,19 @@ class Model:
             ).encode("utf-8")
         ).hexdigest()
 
-        result = None
+        result: Optional[np.ndarray] = None
         if cache:
             if self.shots is not None or self.exp_val:
                 raise NotImplementedError(
                     "Caching with shots or exp_val not yet implemented."
                 )
-            name = f"pqc_{hs}.npy"
+            name: str = f"pqc_{hs}.npy"
 
-            cache_folder = ".cache"
+            cache_folder: str = ".cache"
             if not os.path.exists(cache_folder):
                 os.mkdir(cache_folder)
 
-            file_path = os.path.join(cache_folder, name)
+            file_path: str = os.path.join(cache_folder, name)
 
             if os.path.isfile(file_path):
                 result = np.load(file_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=88
+extend-ignore=E203

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -102,3 +102,39 @@ def test_cache() -> None:
         )
 
         assert result.shape == test_case["shape"], f"Test case: {test_case} failed"
+
+
+def test_initialization() -> None:
+    test_cases = [
+        {
+            "initialization": "random",
+        },
+        {
+            "initialization": "zeros",
+        },
+        {
+            "initialization": "zero-controlled",
+        },
+        {
+            "initialization": "pi-controlled",
+        },
+    ]
+
+    for test_case in test_cases:
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=True,
+            initialization=test_case["initialization"],
+            output_qubit=0,
+            shots=1024,
+        )
+
+        _ = model(
+            model.params,
+            inputs=None,
+            noise_params=None,
+            cache=False,
+            execution_type="expval",
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -67,3 +67,6 @@ def test_parameters() -> None:
                 "exception"
             ], f"Got exception with configuration {test_case}: {e}"
             print(f"Exception as intended for {test_case}: {e}")
+
+            # In case of an exception, the model should still print
+            str(model)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,10 @@
 from qml_essentials.model import Model
+from qml_essentials.ansaetze import Ansaetze
 import pytest
+import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def test_parameters() -> None:
@@ -138,3 +143,100 @@ def test_initialization() -> None:
             cache=False,
             execution_type="expval",
         )
+
+def test_ansaetze() -> None:
+    ansatz_cases = Ansaetze.get_available()
+
+    for ansatz in ansatz_cases:
+        # Skipping Circuit_15, as it is not yet correctly implemented
+        if ansatz.__name__ == "Circuit_15":
+            continue
+
+        logger.info(f"Testing Ansatz: {ansatz.__name__}")
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type=ansatz.__name__,
+            data_reupload=True,
+            initialization="random",
+            output_qubit=0,
+            shots=1024,
+        )
+
+        _ = model(
+            model.params,
+            inputs=None,
+            noise_params=None,
+            cache=False,
+            execution_type="expval",
+        )
+
+
+def test_multi_input() -> None:
+    input_cases = [
+        np.random.rand(1),
+        np.random.rand(1, 1),
+        np.random.rand(1, 2),
+        np.random.rand(1, 3),
+        np.random.rand(2, 1),
+        np.random.rand(20, 1),
+    ]
+    input_cases = [ 2 * np.pi * i for i in input_cases ]
+    input_cases.append(None)
+
+    for inputs in input_cases:
+        logger.info(f"Testing input with shape: "\
+                f"{inputs.shape if inputs is not None else 'None'}")
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=True,
+            initialization="random",
+            output_qubit=0,
+            shots=1024,
+        )
+
+        out = model(
+            model.params,
+            inputs=inputs,
+            noise_params=None,
+            cache=False,
+            execution_type="expval",
+        )
+
+        if inputs is not None:
+            if len(out.shape) > 0:
+                assert out.shape[0] == inputs.shape[0], \
+                        f"batch dimension mismatch, expected {inputs.shape[0]} " \
+                        f"as an output dimension, but got {out.shape[0]}"
+            else:
+                assert inputs.shape[0] == 1, \
+                        f"expected one elemental input for zero dimensional output"
+        else:
+            assert len(out.shape) == 0, \
+                        f"expected one elemental output for empty input"
+
+
+def test_dru() -> None:
+    dru_cases = [False, True]
+
+    for dru in dru_cases:
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=dru,
+            initialization="random",
+            output_qubit=0,
+            shots=1024,
+        )
+
+        _ = model(
+            model.params,
+            inputs=None,
+            noise_params=None,
+            cache=False,
+            execution_type="expval",
+        )
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,42 +1,32 @@
 from qml_essentials.model import Model
+import pytest
 
 
 def test_parameters() -> None:
     test_cases = [
         {
             "shots": -1,
-            "state_vector": False,
-            "exp_val": True,
+            "execution_type": "expval",
             "exception": False,
         },
         {
             "shots": -1,
-            "state_vector": True,
-            "exp_val": False,
+            "execution_type": "density",
             "exception": False,
         },
         {
             "shots": 1024,
-            "state_vector": False,
-            "exp_val": False,
+            "execution_type": "probs",
             "exception": False,
         },
         {
             "shots": 1024,
-            "state_vector": False,
-            "exp_val": True,
+            "execution_type": "expval",
             "exception": False,
         },
         {
-            "shots": -1,
-            "state_vector": True,
-            "exp_val": True,
-            "exception": True,
-        },
-        {
             "shots": 1024,
-            "state_vector": True,
-            "exp_val": False,
+            "execution_type": "density",
             "exception": True,
         },
     ]
@@ -52,21 +42,22 @@ def test_parameters() -> None:
             shots=test_case["shots"],
         )
 
-        try:
-            result = model(
-                model.params,
-                inputs=None,
-                noise_params=None,
-                cache=False,
-                state_vector=test_case["state_vector"],
-                exp_val=test_case["exp_val"],
-            )
+        result = model(
+            model.params,
+            inputs=None,
+            noise_params=None,
+            cache=False,
+            execution_type=test_case["execution_type"],
+        )
+        if test_case["exception"]:
+            with pytest.warns(UserWarning):
+                result = model(
+                    model.params,
+                    inputs=None,
+                    noise_params=None,
+                    cache=False,
+                    execution_type=test_case["execution_type"],
+                )
+        else:
             print(f"Test case {test_case}: {result}")
-        except Exception as e:
-            assert test_case[
-                "exception"
-            ], f"Got exception with configuration {test_case}: {e}"
-            print(f"Exception as intended for {test_case}: {e}")
-
-            # In case of an exception, the model should still print
             str(model)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,13 +42,6 @@ def test_parameters() -> None:
             shots=test_case["shots"],
         )
 
-        result = model(
-            model.params,
-            inputs=None,
-            noise_params=None,
-            cache=False,
-            execution_type=test_case["execution_type"],
-        )
         if test_case["exception"]:
             with pytest.warns(UserWarning):
                 result = model(
@@ -59,5 +52,53 @@ def test_parameters() -> None:
                     execution_type=test_case["execution_type"],
                 )
         else:
-            print(f"Test case {test_case}: {result}")
+            _ = model(
+                model.params,
+                inputs=None,
+                noise_params=None,
+                cache=False,
+                execution_type=test_case["execution_type"],
+            )
+
             str(model)
+
+
+def test_cache() -> None:
+    test_cases = [
+        {
+            "shots": 1024,
+            "execution_type": "expval",
+            "shape": (),
+        },
+        {
+            "shots": -1,
+            "execution_type": "density",
+            "shape": (4, 4),
+        },
+        {
+            "shots": 1024,
+            "execution_type": "probs",
+            "shape": (2,),
+        },
+    ]
+
+    for test_case in test_cases:
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=True,
+            initialization="random",
+            output_qubit=0,
+            shots=test_case["shots"],
+        )
+
+        result = model(
+            model.params,
+            inputs=None,
+            noise_params=None,
+            cache=True,
+            execution_type=test_case["execution_type"],
+        )
+
+        assert result.shape == test_case["shape"], f"Test case: {test_case} failed"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,69 @@
+from qml_essentials.model import Model
+
+
+def test_parameters() -> None:
+    test_cases = [
+        {
+            "shots": -1,
+            "state_vector": False,
+            "exp_val": True,
+            "exception": False,
+        },
+        {
+            "shots": -1,
+            "state_vector": True,
+            "exp_val": False,
+            "exception": False,
+        },
+        {
+            "shots": 1024,
+            "state_vector": False,
+            "exp_val": False,
+            "exception": False,
+        },
+        {
+            "shots": 1024,
+            "state_vector": False,
+            "exp_val": True,
+            "exception": False,
+        },
+        {
+            "shots": -1,
+            "state_vector": True,
+            "exp_val": True,
+            "exception": True,
+        },
+        {
+            "shots": 1024,
+            "state_vector": True,
+            "exp_val": False,
+            "exception": True,
+        },
+    ]
+
+    for test_case in test_cases:
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=True,
+            initialization="random",
+            output_qubit=0,
+            shots=test_case["shots"],
+        )
+
+        try:
+            result = model(
+                model.params,
+                inputs=None,
+                noise_params=None,
+                cache=False,
+                state_vector=test_case["state_vector"],
+                exp_val=test_case["exp_val"],
+            )
+            print(f"Test case {test_case}: {result}")
+        except Exception as e:
+            assert test_case[
+                "exception"
+            ], f"Got exception with configuration {test_case}: {e}"
+            print(f"Exception as intended for {test_case}: {e}")


### PR DESCRIPTION
depends on #2 

So quite a journey; here are the major changes
- added `execution_type` parameter (replaces `state_vector` and `exp_val`)
- added getter/setter for `noise_params` to handle all-zero dicts
- added getter/setter for `execution_type` to validate mode and raise warning depending if `shots` is set
- added getter/setter for `shots` to catch <= 0 shot values
- added caching depending on `execution_type`
- removed post processing if `execution_type` is `probs` because I feel like this should be handled outside of the model
- added two different QNodes to handle dynamic routing of `default.mixed` and `default.qubit` device depending on `execution_type`
- added tests for `execution_type` related parameters, caching and parameter initialization

Bumped version to `0.1.8`