### PR TITLE
Kwargs in forward pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.8"
+version = "0.1.9"
 description = ""
 authors = ["Melvin Strobl <lc3267@kit.edu>"]
 readme = "README.md"

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -34,6 +34,11 @@ class Model:
         depending if data_reupload is True and parameters_per_layer is given by
         the chosen ansatz.
 
+        The model is initialized with the following parameters as defaults:
+        - noise_params: None
+        - execution_type: "expval"
+        - shots: None
+
         Args:
             n_qubits (int): The number of qubits in the circuit.
             n_layers (int): The number of layers in the circuit.

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -307,7 +307,7 @@ class Model:
         inputs: np.ndarray,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
-        execution_type: str = "expval",
+        execution_type: Optional[str] = None,
     ) -> np.ndarray:
         """
         Perform a forward pass of the quantum circuit.
@@ -317,11 +317,13 @@ class Model:
                 [n_layers, n_qubits*n_params_per_layer].
             inputs (np.ndarray): Input vector of shape [1].
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
-                Defaults to None.
+                Defaults to None which results in the last
+                set noise parameters being used.
             cache (Optional[bool], optional): Whether to cache the results.
                 Defaults to False.
             execution_type (str, optional): The type of execution.
-                Must be one of 'expval', 'density', or 'probs'. Defaults to 'expval'.
+                Must be one of 'expval', 'density', or 'probs'. Defaults to None
+                which results in the last set execution type being used.
 
         Returns:
             np.ndarray: The output of the quantum circuit.
@@ -341,7 +343,7 @@ class Model:
         inputs: np.ndarray,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
-        execution_type: str = "expval",
+        execution_type: Optional[str] = None,
     ) -> np.ndarray:
         """
         Perform a forward pass of the quantum circuit.
@@ -351,11 +353,13 @@ class Model:
                 [n_layers, n_qubits*n_params_per_layer].
             inputs (np.ndarray): Input vector of shape [1].
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
-                Defaults to None.
+                Defaults to None which results in the last
+                set noise parameters being used.
             cache (Optional[bool], optional): Whether to cache the results.
                 Defaults to False.
             execution_type (str, optional): The type of execution.
-                Must be one of 'expval', 'density', or 'probs'. Defaults to 'expval'.
+                Must be one of 'expval', 'density', or 'probs'. Defaults to None
+                which results in the last set execution type being used.
 
         Returns:
             np.ndarray: The output of the quantum circuit.
@@ -371,8 +375,10 @@ class Model:
                 expectation value is True.
         """
         # set the parameters as object attributes
-        self.noise_params = noise_params
-        self.execution_type = execution_type
+        if noise_params is not None:
+            self.noise_params = noise_params
+        if execution_type is not None:
+            self.execution_type = execution_type
 
         # the qasm representation contains the bound parameters, thus it is ok to hash that
         hs = hashlib.md5(


### PR DESCRIPTION
This PR adds
- support for setting `noise_params` and `execution_type` outside of the `_forward` method
- test for the parameters being set before and after calling `_forward`