### PR TITLE
Global measurements

### DIFF
--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -118,9 +118,7 @@ class Model:
         elif initialization == "zeros":
             self.params: np.ndarray = np.zeros(params_shape, requires_grad=True)
         elif initialization == "pi":
-            self.params: np.ndarray = (
-                np.ones(params_shape, requires_grad=True) * np.pi
-            )
+            self.params: np.ndarray = np.ones(params_shape, requires_grad=True) * np.pi
         elif initialization == "zero-controlled":
             self.params: np.ndarray = rng.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True
@@ -279,9 +277,7 @@ class Model:
             if self.noise_params is not None:
                 for q in range(self.n_qubits):
                     qml.BitFlip(self.noise_params.get("BitFlip", 0.0), wires=q)
-                    qml.PhaseFlip(
-                        self.noise_params.get("PhaseFlip", 0.0), wires=q
-                    )
+                    qml.PhaseFlip(self.noise_params.get("PhaseFlip", 0.0), wires=q)
                     qml.AmplitudeDamping(
                         self.noise_params.get("AmplitudeDamping", 0.0), wires=q
                     )
@@ -370,9 +366,7 @@ class Model:
                     (2**len(output_qubit),).
         """
         # Call forward method which handles the actual caching etc.
-        return self._forward(
-            params, inputs, noise_params, cache, execution_type
-        )
+        return self._forward(params, inputs, noise_params, cache, execution_type)
 
     def _forward(
         self,
@@ -452,10 +446,7 @@ class Model:
 
         if result is None:
             # if density matrix requested or noise params used
-            if (
-                self.execution_type == "density"
-                or self.noise_params is not None
-            ):
+            if self.execution_type == "density" or self.noise_params is not None:
                 result = self.circuit_mixed(
                     params=params,
                     inputs=inputs,
@@ -466,9 +457,7 @@ class Model:
                     inputs=inputs,
                 )
 
-        if self.execution_type == "expval" and isinstance(
-            self.output_qubit, list
-        ):
+        if self.execution_type == "expval" and isinstance(self.output_qubit, list):
             result = np.stack(result)
 
         if cache:

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -26,6 +26,7 @@ class Model:
         initialization: str = "random",
         output_qubit: Union[List[int], int] = 0,
         shots: Optional[int] = None,
+        random_seed: int = 1000,
     ) -> None:
         """
         Initialize the quantum circuit model.
@@ -55,6 +56,8 @@ class Model:
                 type.
             shots (Optional[int], optional): The number of shots to use for
                 the quantum device. Defaults to None.
+            random_seed (int, optional): seed for the random number generator
+                in initialization is "random", Defaults to 1000.
 
         Returns:
             None
@@ -107,8 +110,9 @@ class Model:
                 )
             return params
 
+        rng = np.random.default_rng(random_seed)
         if initialization == "random":
-            self.params: np.ndarray = np.random.uniform(
+            self.params: np.ndarray = rng.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True
             )
         elif initialization == "zeros":
@@ -118,12 +122,12 @@ class Model:
                 np.ones(params_shape, requires_grad=True) * np.pi
             )
         elif initialization == "zero-controlled":
-            self.params: np.ndarray = np.random.uniform(
+            self.params: np.ndarray = rng.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True
             )
             self.params = set_control_params(self.params, 0)
         elif initialization == "pi-controlled":
-            self.params: np.ndarray = np.random.uniform(
+            self.params: np.ndarray = rng.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True
             )
             self.params = set_control_params(self.params, np.pi)

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -175,7 +175,8 @@ class Model:
         if value == "density" and self.output_qubit != -1:
             warnings.warn(
                 f"{value} measurement does ignore output_qubit, which is "
-                f"{self.output_qubit}."
+                f"{self.output_qubit}.",
+                UserWarning,
             )
 
         if value == "probs" and self.shots is None:

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -47,7 +47,7 @@ class Model:
             data_reupload (bool, optional): Whether to reupload data to the
                 quantum device on each measurement. Defaults to True.
             initialization (str, optional): The strategy to initialize the parameters.
-                Can be "random", "zeros", "zero-controlled", or "pi-controlled".
+                Can be "random", "zeros", "zero-controlled", "pi", or "pi-controlled".
                 Defaults to "random".
             output_qubit (List[int], int, optional): The index of the output
                 qubit (or qubits). When set to -1 all qubits are measured, or a
@@ -113,6 +113,10 @@ class Model:
             )
         elif initialization == "zeros":
             self.params: np.ndarray = np.zeros(params_shape, requires_grad=True)
+        elif initialization == "pi":
+            self.params: np.ndarray = (
+                np.ones(params_shape, requires_grad=True) * np.pi
+            )
         elif initialization == "zero-controlled":
             self.params: np.ndarray = np.random.uniform(
                 0, 2 * np.pi, params_shape, requires_grad=True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -336,49 +336,57 @@ def test_local_and_global_meas() -> None:
             "execution_type": "expval",
             "output_qubit": -1,
             "shots": -1,
-            "out_shape": (3,)
+            "out_shape": (3,),
+            "warning": False,
         },
         {
             "execution_type": "expval",
             "output_qubit": 0,
             "shots": -1,
-            "out_shape": (3,)
+            "out_shape": (3,),
+            "warning": False,
         },
         {
             "execution_type": "expval",
             "output_qubit": [0, 1],
             "shots": -1,
-            "out_shape": (2, 3)
+            "out_shape": (2, 3),
+            "warning": False,
         },
         {
             "execution_type": "density",
             "output_qubit": -1,
             "shots": -1,
-            "out_shape": (3, 4, 4)
+            "out_shape": (3, 4, 4),
+            "warning": False,
         },
         {
             "execution_type": "density",
             "output_qubit": 0,
             "shots": -1,
-            "out_shape": (3, 4, 4)
+            "out_shape": (3, 4, 4),
+            "warning": True,
         },
         {
             "execution_type": "probs",
             "output_qubit": -1,
             "shots": 1024,
-            "out_shape": (3, 4)
+            "out_shape": (3, 4),
+            "warning": False,
         },
         {
             "execution_type": "probs",
             "output_qubit": 0,
             "shots": 1024,
-            "out_shape": (3, 2)
+            "out_shape": (3, 2),
+            "warning": False,
         },
         {
             "execution_type": "probs",
             "output_qubit": [0, 1],
             "shots": 1024,
-            "out_shape": (3, 4)
+            "out_shape": (3, 4),
+            "warning": False,
         },
     ]
 
@@ -392,14 +400,23 @@ def test_local_and_global_meas() -> None:
             output_qubit=test_case["output_qubit"],
             shots=test_case["shots"],
         )
-
-        out = model(
-            model.params,
-            inputs=inputs,
-            noise_params=None,
-            cache=False,
-            execution_type=test_case["execution_type"],
-        )
+        if test_case["warning"]:
+            with pytest.warns(UserWarning):
+                out = model(
+                    model.params,
+                    inputs=inputs,
+                    noise_params=None,
+                    cache=False,
+                    execution_type=test_case["execution_type"],
+                )
+        else:
+            out = model(
+                model.params,
+                inputs=inputs,
+                noise_params=None,
+                cache=False,
+                execution_type=test_case["execution_type"],
+            )
 
         assert (
             out.shape == test_case["out_shape"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,6 +20,11 @@ def test_parameters() -> None:
             "exception": False,
         },
         {
+            "shots": -1,
+            "execution_type": "global_mean",
+            "exception": False,
+        },
+        {
             "shots": 1024,
             "execution_type": "probs",
             "exception": False,
@@ -33,6 +38,11 @@ def test_parameters() -> None:
             "shots": 1024,
             "execution_type": "density",
             "exception": True,
+        },
+        {
+            "shots": 1024,
+            "execution_type": "global_mean",
+            "exception": False,
         },
     ]
 
@@ -324,3 +334,81 @@ def test_local_state() -> None:
         # check if setting in the forward call is working
         assert model.noise_params == test_case["noise_params"]
         assert model.execution_type == test_case["execution_type"]
+
+
+def test_local_and_global_meas() -> None:
+    inputs = np.array([0.1, 0.2, 0.3])
+    test_cases = [
+        {
+            "execution_type": "expval",
+            "output_qubit": -1,
+            "shots": -1,
+            "out_shape": (3,)
+        },
+        {
+            "execution_type": "expval",
+            "output_qubit": 0,
+            "shots": -1,
+            "out_shape": (3,)
+        },
+        {
+            "execution_type": "global_mean",
+            "output_qubit": -1,
+            "shots": -1,
+            "out_shape": (3,)
+        },
+        {
+            "execution_type": "global_mean",
+            "output_qubit": 0,
+            "shots": -1,
+            "out_shape": (3,)
+        },
+        {
+            "execution_type": "density",
+            "output_qubit": -1,
+            "shots": -1,
+            "out_shape": (3, 4, 4)
+        },
+        {
+            "execution_type": "density",
+            "output_qubit": 0,
+            "shots": -1,
+            "out_shape": (3, 4, 4)
+        },
+        {
+            "execution_type": "probs",
+            "output_qubit": -1,
+            "shots": 1024,
+            "out_shape": (3, 4)
+        },
+        {
+            "execution_type": "probs",
+            "output_qubit": 0,
+            "shots": 1024,
+            "out_shape": (3, 2)
+        },
+    ]
+
+
+    for test_case in test_cases:
+        model = Model(
+            n_qubits=2,
+            n_layers=1,
+            circuit_type="Circuit_19",
+            data_reupload=True,
+            initialization="random",
+            output_qubit=test_case["output_qubit"],
+            shots=test_case["shots"],
+        )
+
+        out = model(
+            model.params,
+            inputs=inputs,
+            noise_params=None,
+            cache=False,
+            execution_type=test_case["execution_type"],
+        )
+
+        assert (
+            out.shape == test_case["out_shape"]
+        ), f"{test_case['execution_type']}: {out}"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,11 +20,6 @@ def test_parameters() -> None:
             "exception": False,
         },
         {
-            "shots": -1,
-            "execution_type": "global_mean",
-            "exception": False,
-        },
-        {
             "shots": 1024,
             "execution_type": "probs",
             "exception": False,
@@ -38,11 +33,6 @@ def test_parameters() -> None:
             "shots": 1024,
             "execution_type": "density",
             "exception": True,
-        },
-        {
-            "shots": 1024,
-            "execution_type": "global_mean",
-            "exception": False,
         },
     ]
 
@@ -352,16 +342,10 @@ def test_local_and_global_meas() -> None:
             "out_shape": (3,)
         },
         {
-            "execution_type": "global_mean",
-            "output_qubit": -1,
+            "execution_type": "expval",
+            "output_qubit": [0, 1],
             "shots": -1,
-            "out_shape": (3,)
-        },
-        {
-            "execution_type": "global_mean",
-            "output_qubit": 0,
-            "shots": -1,
-            "out_shape": (3,)
+            "out_shape": (2, 3)
         },
         {
             "execution_type": "density",
@@ -386,6 +370,12 @@ def test_local_and_global_meas() -> None:
             "output_qubit": 0,
             "shots": 1024,
             "out_shape": (3, 2)
+        },
+        {
+            "execution_type": "probs",
+            "output_qubit": [0, 1],
+            "shots": 1024,
+            "out_shape": (3, 4)
         },
     ]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -389,7 +389,6 @@ def test_local_and_global_meas() -> None:
         },
     ]
 
-
     for test_case in test_cases:
         model = Model(
             n_qubits=2,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -123,6 +123,9 @@ def test_initialization() -> None:
         {
             "initialization": "pi-controlled",
         },
+        {
+            "initialization": "pi",
+        },
     ]
 
     for test_case in test_cases:


### PR DESCRIPTION
This PR allows to specify multiple output qubits, over which computes the local PauliZ expectation value.
The mean calculation is not included, as this probably fits better in a post-processing step.
Additionally when the output_qubit is set to -1 (i.e. global measurement) and the "expval" execution type is selected, a tensored PauliZ over all qubits is executed.
This addresses FR #6
