### PR TITLE
added none-able input

### DIFF
--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -343,7 +343,7 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (Optional[np.ndarray]): Optional input vector of shape [1].
+            inputs (Optional[np.ndarray]): Optional input vector with length of batch.
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.
@@ -382,7 +382,7 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (Optional[np.ndarray]): Optional input vector of shape [1].
+            inputs (Optional[np.ndarray]): Optional input vector with length of batch.
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -332,7 +332,7 @@ class Model:
     def __call__(
         self,
         params: np.ndarray,
-        inputs: np.ndarray,
+        inputs: np.ndarray = None,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
@@ -343,7 +343,7 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (np.ndarray): Input vector of shape [1].
+            inputs (Optional[np.ndarray]): Optional input vector of shape [1].
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.
@@ -371,7 +371,7 @@ class Model:
     def _forward(
         self,
         params: np.ndarray,
-        inputs: np.ndarray,
+        inputs: Optional[np.ndarray] = None,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
@@ -382,7 +382,7 @@ class Model:
         Args:
             params (np.ndarray): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (np.ndarray): Input vector of shape [1].
+            inputs (Optional[np.ndarray]): Optional input vector of shape [1].
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.


### PR DESCRIPTION
this PR allows None-input to the model.
Fallback functionality is already implemented, so there is no reason to not make the input variable optional (None by default)