### PR TITLE
Force mean value

### DIFF
--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -7,7 +7,7 @@ import numpy as np
 class Coefficients:
 
     @staticmethod
-    def sample_coefficients(model: Model) -> np.ndarray:
+    def sample_coefficients(model: Model, **kwargs) -> np.ndarray:
         """
         Sample the Fourier coefficients of a given model
         using Pennylane fourier.coefficients function.
@@ -22,7 +22,10 @@ class Coefficients:
         Returns:
             np.ndarray: The sampled Fourier coefficients.
         """
-        partial_circuit = partial(model, model.params)
+        kwargs.setdefault("force_mean", True)
+        kwargs.setdefault("execution_type", "expval")
+
+        partial_circuit = partial(model, model.params, **kwargs)
         coeffs = coefficients(partial_circuit, 1, model.degree)
 
         if not np.isclose(np.sum(coeffs).imag, 0.0, rtol=1.0e-5):

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -18,6 +18,7 @@ class Coefficients:
 
         Args:
             model (Model): The model to sample.
+            kwargs (Any): Additional keyword arguments for the model function.
 
         Returns:
             np.ndarray: The sampled Fourier coefficients.

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -33,6 +33,7 @@ class Entanglement:
             float: Entangling capacity of the given circuit. It is guaranteed
                 to be between 0.0 and 1.0.
         """
+
         def _meyer_wallach(
             evaluate: Callable[[np.ndarray], np.ndarray],
             n_qubits: int,

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -506,12 +506,13 @@ class Model:
                 )
 
         if self.execution_type == "expval" and isinstance(self.output_qubit, list):
-            result = np.stack(result)
+            if isinstance(result, list):
+                result = np.stack(result)
 
             # Calculating mean value after stacking, to not
             # discard gradient information
             if force_mean:
-                result = np.mean(result, axis=0)
+                result = result.mean(axis=0)
 
         if cache:
             np.save(file_path, result)

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -373,6 +373,7 @@ class Model:
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
+        force_mean: Optional[bool] = False,
     ) -> np.ndarray:
         """
         Perform a forward pass of the quantum circuit.
@@ -403,7 +404,14 @@ class Model:
                     (2**len(output_qubit),).
         """
         # Call forward method which handles the actual caching etc.
-        return self._forward(params, inputs, noise_params, cache, execution_type)
+        return self._forward(
+            params=params,
+            inputs=inputs,
+            noise_params=noise_params,
+            cache=cache,
+            execution_type=execution_type,
+            force_mean=force_mean,
+        )
 
     def _forward(
         self,
@@ -412,6 +420,7 @@ class Model:
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
+        force_mean: Optional[bool] = False,
     ) -> np.ndarray:
         """
         Perform a forward pass of the quantum circuit.
@@ -496,6 +505,11 @@ class Model:
 
         if self.execution_type == "expval" and isinstance(self.output_qubit, list):
             result = np.stack(result)
+
+            # Calculating mean value after stacking, to not
+            # discard gradient information
+            if force_mean:
+                result = np.mean(result, axis=0)
 
         if cache:
             np.save(file_path, result)

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -336,15 +336,17 @@ class Model:
         elif self.execution_type == "expval":
             # global measurement (tensored Pauli Z, i.e. parity)
             if self.output_qubit == -1:
-                obs = qml.Hamiltonian(
-                    [1.0] * self.n_qubits,
-                    [qml.PauliZ(q) for q in range(self.n_qubits)],
-                    simplify=True,
+                obs = qml.simplify(
+                    qml.Hamiltonian(
+                        [1.0] * self.n_qubits,
+                        [qml.PauliZ(q) for q in range(self.n_qubits)],
+                    )
                 )
                 return qml.expval(obs)
             # local measurement(s)
             elif isinstance(self.output_qubit, int):
                 return qml.expval(qml.PauliZ(self.output_qubit))
+            # n-local measurenment
             else:
                 return [qml.expval(qml.PauliZ(q)) for q in self.output_qubit]
         # run default simulation and get probs

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -18,7 +18,7 @@ def test_coefficients() -> None:
             "n_bins": 10,
             "n_samples": 200,
             "n_input_samples": 2,
-            "result": 1.858,
+            "output_qubit": 0,
         },
         {
             "circuit_type": "Circuit_9",
@@ -27,7 +27,16 @@ def test_coefficients() -> None:
             "n_bins": 10,
             "n_samples": 200,
             "n_input_samples": 2,
-            "result": 2.629,
+            "output_qubit": 0,
+        },
+        {
+            "circuit_type": "Circuit_9",
+            "n_qubits": 4,
+            "n_layers": 1,
+            "n_bins": 10,
+            "n_samples": 200,
+            "n_input_samples": 2,
+            "output_qubit": [0, 1, 2, 3],
         },
     ]
 
@@ -38,7 +47,7 @@ def test_coefficients() -> None:
             circuit_type=test_case["circuit_type"],
             data_reupload=True,
             initialization="random",
-            output_qubit=0,
+            output_qubit=test_case["output_qubit"],
         )
 
         coeffs = Coefficients.sample_coefficients(model)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -13,26 +13,50 @@ def test_parameters() -> None:
         {
             "shots": -1,
             "execution_type": "expval",
+            "output_qubit": 0,
+            "force_mean": False,
+            "exception": False,
+        },
+        {
+            "shots": -1,
+            "execution_type": "expval",
+            "output_qubit": [0, 1],
+            "force_mean": False,
+            "exception": False,
+        },
+        {
+            "shots": -1,
+            "execution_type": "expval",
+            "output_qubit": [0, 1],
+            "force_mean": True,
             "exception": False,
         },
         {
             "shots": -1,
             "execution_type": "density",
+            "output_qubit": 0,
+            "force_mean": False,
             "exception": False,
         },
         {
             "shots": 1024,
             "execution_type": "probs",
+            "output_qubit": 0,
+            "force_mean": False,
             "exception": False,
         },
         {
             "shots": 1024,
             "execution_type": "expval",
+            "output_qubit": 0,
+            "force_mean": False,
             "exception": False,
         },
         {
             "shots": 1024,
             "execution_type": "density",
+            "output_qubit": 0,
+            "force_mean": False,
             "exception": True,
         },
     ]
@@ -44,28 +68,39 @@ def test_parameters() -> None:
             circuit_type="Circuit_19",
             data_reupload=True,
             initialization="random",
-            output_qubit=0,
+            output_qubit=test_case["output_qubit"],
             shots=test_case["shots"],
         )
 
         if test_case["exception"]:
             with pytest.warns(UserWarning):
-                result = model(
+                _ = model(
                     model.params,
                     inputs=None,
                     noise_params=None,
                     cache=False,
                     execution_type=test_case["execution_type"],
+                    force_mean=test_case["force_mean"],
                 )
         else:
-            _ = model(
+            result = model.__call__(
                 model.params,
                 inputs=None,
                 noise_params=None,
                 cache=False,
                 execution_type=test_case["execution_type"],
+                force_mean=test_case["force_mean"],
             )
 
+            if isinstance(test_case["output_qubit"], list):
+                if test_case["force_mean"]:
+                    assert (
+                        result.shape[0] == 1
+                    ), f"Shape of {test_case['output_qubit']} is not correct."
+                else:
+                    assert result.shape[0] == len(
+                        test_case["output_qubit"]
+                    ), f"Shape of {test_case['output_qubit']} is not correct."
             str(model)
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,7 +92,8 @@ def test_parameters() -> None:
                 force_mean=test_case["force_mean"],
             )
 
-            assert result.requires_grad == True, "No gradients available in output."
+            if test_case["shots"] < 0:
+                assert result.requires_grad == True, "No gradients available in output."
 
             if isinstance(test_case["output_qubit"], list):
                 if test_case["force_mean"]:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -472,6 +472,28 @@ def test_local_and_global_meas() -> None:
         ), f"{test_case['execution_type']}: {out}"
 
 
+def test_parity() -> None:
+    model_a = Model(
+        n_qubits=2,
+        n_layers=1,
+        circuit_type="Circuit_1",
+        output_qubit=[0, 1],
+    )
+    model_b = Model(
+        n_qubits=2,
+        n_layers=1,
+        circuit_type="Circuit_1",
+        output_qubit=-1,
+    )
+
+    result_a = model_a(model_a.params, inputs=None, cache=False, force_mean=True)
+    result_b = model_b(model_a.params, inputs=None, cache=False)  # use same params!
+
+    assert not np.allclose(
+        result_a, result_b
+    ), f"Models should be different! Got {result_a} and {result_b}"
+
+
 if __name__ == "__main__":
     test_parameters()
     test_cache()
@@ -482,3 +504,4 @@ if __name__ == "__main__":
     test_dru()
     test_local_state()
     test_local_and_global_meas()
+    test_parity()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -93,7 +93,7 @@ def test_parameters() -> None:
             )
 
             if test_case["shots"] < 0:
-                assert result.requires_grad == True, "No gradients available in output."
+                assert result.requires_grad, "No gradients available in output."
 
             if isinstance(test_case["output_qubit"], list):
                 if test_case["force_mean"]:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,6 +92,8 @@ def test_parameters() -> None:
                 force_mean=test_case["force_mean"],
             )
 
+            assert result.requires_grad == True, "No gradients available in output."
+
             if isinstance(test_case["output_qubit"], list):
                 if test_case["force_mean"]:
                     assert (
@@ -467,3 +469,7 @@ def test_local_and_global_meas() -> None:
         assert (
             out.shape == test_case["out_shape"]
         ), f"{test_case['execution_type']}: {out}"
+
+
+if __name__ == "__main__":
+    test_parameters()


### PR DESCRIPTION
This PR resolves #24 by implementing
- an optional (default False) flag in the forward call which causes a mean value calculation of the output if multiple qubits for measurement are selected (no parity)
- tests to verify above implementation
- test for checking gradient as discussed in the issue
- test for checking non-equality of parity vs n-local measurement
- added `force_mean` flag when calculating coefficients
- test for calculating coefficients on n-local circuit
- fixed deprecation warning in parity Hamiltonian

**Somehow there is no gradient information available when running with shots**. However I think this is out of scope for this PR -> #29 