### PR TITLE
Remove epsilon in expressibility

### DIFF
--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -120,7 +120,6 @@ class Expressibility:
         for i, f in enumerate(fidelities):
             z[i], _ = np.histogram(f, bins=y)
 
-        # Transpose because this allows a direct comparison with the haar integral
         z = z / n_samples
 
         return x, y, z

--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -102,7 +102,6 @@ class Expressibility:
             Tuple[np.ndarray, np.ndarray, np.ndarray]: Tuple containing the
                 input samples, bin edges, and histogram values.
         """
-        epsilon = 1e-5
 
         x_domain = [-1 * np.pi, 1 * np.pi]
         x = np.linspace(x_domain[0], x_domain[1], n_input_samples, requires_grad=False)
@@ -116,11 +115,8 @@ class Expressibility:
         )
         z: np.ndarray = np.zeros((len(x), n_bins))
 
-        y: np.ndarray = np.linspace(0, 1 + epsilon, n_bins + 1)
-        # FIXME: somehow I get nan's in the histogram,
-        # when directly creating bins until n
-        # workaround hack is to add a small epsilon
-        # could it be related to sampling issues?
+        y: np.ndarray = np.linspace(0, 1, n_bins + 1)
+
         for i, f in enumerate(fidelities):
             z[i], _ = np.histogram(f, bins=y)
 

--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -113,7 +113,7 @@ class Expressibility:
             model=model,
             kwargs=kwargs,
         )
-        z: np.ndarray = np.zeros((len(x), n_bins))
+        z: np.ndarray = np.zeros((n_input_samples, n_bins))
 
         y: np.ndarray = np.linspace(0, 1, n_bins + 1)
 


### PR DESCRIPTION
As the problem in #18 could not be reproduced, the epsilon for the fidelity histogram was removed.
This PR resolves #18.