### PR TITLE
Ent param init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.15"
+version = "0.1.16"
 description = ""
 authors = ["Melvin Strobl <melvin.strobl@kit.edu>", "Maja Franz <maja.franz@oth-regensburg.de>"]
 readme = "README.md"

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -12,7 +12,10 @@ class Entanglement:
 
     @staticmethod
     def meyer_wallach(
-        model: Model, n_samples: Optional[int | None], seed: Optional[int], **kwargs: Any  # type: ignore
+        model: Model,
+        n_samples: Optional[int | None],
+        seed: Optional[int],
+        **kwargs: Any,
     ) -> float:
         """
         Calculates the entangling capacity of a given quantum circuit

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -12,7 +12,7 @@ class Entanglement:
 
     @staticmethod
     def meyer_wallach(
-        model: Model, n_samples: int, seed: Optional[int], **kwargs: Any  # type: ignore
+        model: Model, n_samples: Optional[int | None], seed: Optional[int], **kwargs: Any  # type: ignore
     ) -> float:
         """
         Calculates the entangling capacity of a given quantum circuit
@@ -21,6 +21,7 @@ class Entanglement:
         Args:
             model (Callable): Function that models the quantum circuit.
             n_samples (int): Number of samples per qubit.
+                If None or < 0, the current parameters of the model are used
             seed (Optional[int]): Seed for the random number generator.
             kwargs (Any): Additional keyword arguments for the model function.
 
@@ -29,7 +30,7 @@ class Entanglement:
                 to be between 0.0 and 1.0.
         """
         rng = np.random.default_rng(seed)
-        if n_samples > 0:
+        if n_samples is not None and n_samples > 0:
             assert seed is not None, "Seed must be provided when samples > 0"
             # TODO: maybe switch to JAX rng
             model.initialize_params(rng=rng, repeat=n_samples)

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -441,8 +441,8 @@ class Model:
 
     def __call__(
         self,
-        params: np.ndarray,
-        inputs: np.ndarray,
+        params: Optional[np.ndarray] = None,
+        inputs: Optional[np.ndarray] = None,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
@@ -452,9 +452,11 @@ class Model:
         Perform a forward pass of the quantum circuit.
 
         Args:
-            params (np.ndarray): Weight vector of shape
+            params (Optional[np.ndarray]): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (np.ndarray): Input vector of shape [1].
+                If None, model internal parameters are used.
+            inputs (Optional[np.ndarray]): Input vector of shape [1].
+                If None, zeros are used.
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.
@@ -488,8 +490,8 @@ class Model:
 
     def _forward(
         self,
-        params: np.ndarray,
-        inputs: np.ndarray,
+        params: Optional[np.ndarray] = None,
+        inputs: Optional[np.ndarray] = None,
         noise_params: Optional[Dict[str, float]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
@@ -499,9 +501,11 @@ class Model:
         Perform a forward pass of the quantum circuit.
 
         Args:
-            params (np.ndarray): Weight vector of shape
+            params (Optional[np.ndarray]): Weight vector of shape
                 [n_layers, n_qubits*n_params_per_layer].
-            inputs (np.ndarray): Input vector of shape [1].
+                If None, model internal parameters are used.
+            inputs (Optional[np.ndarray]): Input vector of shape [1].
+                If None, zeros are used.
             noise_params (Optional[Dict[str, float]], optional): The noise parameters.
                 Defaults to None which results in the last
                 set noise parameters being used.

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -4,6 +4,7 @@ import pennylane.numpy as np
 import hashlib
 import os
 import warnings
+from autograd.numpy import numpy_boxes
 
 from qml_essentials.ansaetze import Ansaetze, Circuit
 
@@ -537,8 +538,10 @@ class Model:
         if execution_type is not None:
             self.execution_type = execution_type
 
-        # TODO: dis is important! check dis!
-        self.params = params if params is not None else self.params
+        if numpy_boxes.ArrayBox == type(params):
+            self.params = params._value
+        else:
+            self.params = params
 
         # the qasm representation contains the bound parameters,
         # thus it is ok to hash that
@@ -549,7 +552,7 @@ class Model:
                     "n_layers": self.n_layers,
                     "pqc": self.pqc.__class__.__name__,
                     "dru": self.data_reupload,
-                    "params": self.params,
+                    "params": self.params,  # use safe-params
                     "noise_params": self.noise_params,
                     "execution_type": self.execution_type,
                     "inputs": inputs,
@@ -575,7 +578,7 @@ class Model:
             # if density matrix requested or noise params used
             if self.execution_type == "density" or self.noise_params is not None:
                 result = self.circuit_mixed(
-                    params=self.params,
+                    params=params,  # use arraybox params
                     inputs=inputs,
                 )
             else:
@@ -585,7 +588,7 @@ class Model:
                     )
                 else:
                     result = self.circuit(
-                        params=self.params,
+                        params=params,  # use arraybox params
                         inputs=inputs,
                     )
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -538,10 +538,13 @@ class Model:
         if execution_type is not None:
             self.execution_type = execution_type
 
-        if numpy_boxes.ArrayBox == type(params):
-            self.params = params._value
+        if params is None:
+            params = self.params
         else:
-            self.params = params
+            if numpy_boxes.ArrayBox == type(params):
+                self.params = params._value
+            else:
+                self.params = params
 
         # the qasm representation contains the bound parameters,
         # thus it is ok to hash that

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -533,6 +533,9 @@ class Model:
         if execution_type is not None:
             self.execution_type = execution_type
 
+        # TODO: dis is important! check dis!
+        self.params = params if params is not None else self.params
+
         # the qasm representation contains the bound parameters,
         # thus it is ok to hash that
         hs = hashlib.md5(
@@ -542,7 +545,7 @@ class Model:
                     "n_layers": self.n_layers,
                     "pqc": self.pqc.__class__.__name__,
                     "dru": self.data_reupload,
-                    "params": params,
+                    "params": self.params,
                     "noise_params": self.noise_params,
                     "execution_type": self.execution_type,
                     "inputs": inputs,
@@ -568,7 +571,7 @@ class Model:
             # if density matrix requested or noise params used
             if self.execution_type == "density" or self.noise_params is not None:
                 result = self.circuit_mixed(
-                    params=params,
+                    params=self.params,
                     inputs=inputs,
                 )
             else:
@@ -578,7 +581,7 @@ class Model:
                     )
                 else:
                     result = self.circuit(
-                        params=params,
+                        params=self.params,
                         inputs=inputs,
                     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -653,3 +653,18 @@ def test_parity() -> None:
     assert not np.allclose(
         result_a, result_b
     ), f"Models should be different! Got {result_a} and {result_b}"
+
+
+@pytest.mark.smoketest
+def test_params_store() -> None:
+    model = Model(
+        n_qubits=2,
+        n_layers=1,
+        circuit_type="Circuit_1",
+    )
+    opt = qml.AdamOptimizer(stepsize=0.01)
+
+    def cost(params):
+        return model(params=params, inputs=np.array([0])).mean()._value
+
+    params, cost = opt.step_and_cost(cost, model.params)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -81,6 +81,14 @@ def test_parameters() -> None:
         },
     ]
 
+    # Test the most minimal call
+    model = Model(
+        n_qubits=2,
+        n_layers=1,
+        circuit_type="Circuit_19",
+    )
+    assert (model() == model(model.params)).all()
+
     for test_case in test_cases:
         model = Model(
             n_qubits=2,


### PR DESCRIPTION
This PR fixes how `n_samples` is being treated in the `meyer_wallach` method.
If the parameter is None or <1, then the model internal parameters are being used.
This required setting the model internal parameters in each forward call.