### PR TITLE
optional none input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qml-essentials"
-version = "0.1.16"
+version = "0.1.17"
 description = ""
 authors = ["Melvin Strobl <melvin.strobl@kit.edu>", "Maja Franz <maja.franz@oth-regensburg.de>"]
 readme = "README.md"

--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -83,6 +83,7 @@ class Expressibility:
         n_input_samples: int,
         input_domain: List[float],
         model: Model,
+        scale: bool = False,
         **kwargs: Any,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
@@ -95,12 +96,16 @@ class Expressibility:
             n_input_samples (int): Number of input samples.
             input_domain (List[float]): Input domain.
             model (Callable): Function that models the quantum circuit.
+            scale (bool): Whether to scale the number of samples and bins.
             kwargs (Any): Additional keyword arguments for the model function.
 
         Returns:
             Tuple[np.ndarray, np.ndarray, np.ndarray]: Tuple containing the
                 input samples, bin edges, and histogram values.
         """
+        if scale:
+            n_samples = np.power(2, model.n_qubits) * n_samples
+            n_bins = model.n_qubits * n_bins
 
         if input_domain is None or n_input_samples is None or n_input_samples == 0:
             x = np.zeros((1))
@@ -123,6 +128,9 @@ class Expressibility:
             z[i], _ = np.histogram(f, bins=y)
 
         z = z / n_samples
+
+        if z.shape[0] == 1:
+            z = z.flatten()
 
         return x, y, z
 
@@ -173,6 +181,7 @@ class Expressibility:
         n_qubits: int,
         n_bins: int,
         cache: bool = True,
+        scale: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Calculates theoretical probability density function for random Haar states
@@ -183,6 +192,7 @@ class Expressibility:
             n_qubits (int): number of qubits in the quantum system
             n_bins (int): number of histogram bins
             cache (bool): whether to cache the haar integral
+            scale (bool): whether to scale the number of bins
 
         Returns:
             Tuple[np.ndarray, np.ndarray]:
@@ -190,10 +200,13 @@ class Expressibility:
                 - y component (probabilities): the haar probability density
                   funtion for random Haar states
         """
+        if scale:
+            n_bins = n_qubits * n_bins
+
         x = np.linspace(0, 1, n_bins)
 
         if cache:
-            name = f"haar_{n_qubits}q_{n_bins}s.npy"
+            name = f"haar_{n_qubits}q_{n_bins}s_{'scaled' if scale else ''}.npy"
 
             cache_folder = ".cache"
             if not os.path.exists(cache_folder):

--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -33,16 +33,16 @@ class Expressibility:
         """
         rng = np.random.default_rng(seed)
 
-        # Number of input samples
+        # Generate random parameter sets
+        # We need two sets of parameters, as we are computing fidelities for a
+        # pair of random state vectors
+        model.initialize_params(rng=rng, repeat=n_samples * 2)
+
         n_x_samples = len(x_samples)
 
         # Initialize array to store fidelities
         fidelities: np.ndarray = np.zeros((n_x_samples, n_samples))
 
-        # Generate random parameter sets
-        # We need two sets of parameters, as we are computing fidelities for a
-        # pair of random state vectors
-        model.initialize_params(rng=rng, repeat=n_samples * 2)
         # Batch input samples and parameter sets for efficient computation
         x_samples_batched: np.ndarray = x_samples.reshape(1, -1).repeat(
             n_samples * 2, axis=0
@@ -70,6 +70,7 @@ class Expressibility:
                 )
                 ** 2
             )
+            # TODO: abs instead?
             fidelities[idx] = np.real(fidelity)
 
         return fidelities
@@ -101,7 +102,11 @@ class Expressibility:
                 input samples, bin edges, and histogram values.
         """
 
-        x = np.linspace(*input_domain, n_input_samples, requires_grad=False)
+        if input_domain is None or n_input_samples is None or n_input_samples == 0:
+            x = np.zeros((1))
+            n_input_samples = 1
+        else:
+            x = np.linspace(*input_domain, n_input_samples, requires_grad=False)
 
         fidelities = Expressibility._sample_state_fidelities(
             x_samples=x,

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -595,9 +595,10 @@ class Model:
                         inputs=inputs,
                     )
 
+        if isinstance(result, list):
+            result = np.stack(result)
+
         if self.execution_type == "expval" and self.output_qubit == -1:
-            if isinstance(result, list):
-                result = np.stack(result)
 
             # Calculating mean value after stacking, to not
             # discard gradient information

--- a/tests/test_expressiblity.py
+++ b/tests/test_expressiblity.py
@@ -120,8 +120,10 @@ def test_scaling() -> None:
     _, y = Expressibility.haar_integral(
         n_qubits=model.n_qubits,
         n_bins=4,
-        cache=True,
+        cache=False,
         scale=True,
     )
 
     assert y.shape == (8,)
+
+    _ = Expressibility.kullback_leibler_divergence(z, y)

--- a/tests/test_expressiblity.py
+++ b/tests/test_expressiblity.py
@@ -94,3 +94,34 @@ def test_expressibility() -> None:
         ), f"Expressibility is not {test_case['result']}\
             for circuit ansatz {test_case['circuit_type']}.\
             Was {kl_dist} instead"
+
+
+@pytest.mark.unittest
+@pytest.mark.expensive
+def test_scaling() -> None:
+    model = Model(
+        n_qubits=2,
+        n_layers=1,
+        circuit_type="Circuit_1",
+    )
+
+    _, _, z = Expressibility.state_fidelities(
+        seed=1000,
+        n_bins=4,
+        n_samples=10,
+        n_input_samples=0,
+        input_domain=[0, 2 * np.pi],
+        model=model,
+        scale=True,
+    )
+
+    assert z.shape == (8,)
+
+    _, y = Expressibility.haar_integral(
+        n_qubits=model.n_qubits,
+        n_bins=4,
+        cache=True,
+        scale=True,
+    )
+
+    assert y.shape == (8,)


### PR DESCRIPTION
This PR resolves #60  
It introduces a new parameter for the expressibility (state fidelities and haar integral) which allows scaling the number of samples and number of bins exponentially and linearly with the number of qubits respectively.
Also `n_input_samples` can be None or 0, which will cause `z` having only a single dimension