### PR TITLE
Gate error

### DIFF
--- a/docs/ansaetze.ipynb
+++ b/docs/ansaetze.ipynb
@@ -157,7 +157,7 @@
     "    \"PhaseFlip\": 0.0,\n",
     "    \"AmplitudeDamping\": 0.0,\n",
     "    \"PhaseDamping\": 0.0,\n",
-    "    \"DepolarizingChannel\": 0.0,\n",
+    "    \"Depolarizing\": 0.0,\n",
     "}\n",
     "\n",
     "class MyNoisyHardwareEfficient(Circuit):\n",
@@ -191,7 +191,7 @@
     "        \"PhaseFlip\": 0.02,\n",
     "        \"AmplitudeDamping\": 0.03,\n",
     "        \"PhaseDamping\": 0.04,\n",
-    "        \"DepolarizingChannel\": 0.05,\n",
+    "        \"Depolarizing\": 0.05,\n",
     "})"
    ]
   }

--- a/docs/ansaetze.md
+++ b/docs/ansaetze.md
@@ -117,7 +117,7 @@ noise_params = {
     "PhaseFlip": 0.0,
     "AmplitudeDamping": 0.0,
     "PhaseDamping": 0.0,
-    "DepolarizingChannel": 0.0,
+    "Depolarizing": 0.0,
 }
 ```
 
@@ -161,6 +161,6 @@ model(
         "PhaseFlip": 0.02,
         "AmplitudeDamping": 0.03,
         "PhaseDamping": 0.04,
-        "DepolarizingChannel": 0.05,
+        "Depolarizing": 0.05,
 })
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,8 +86,9 @@ Noise can be added to the model by providing a `noise_params` argument, when cal
 - `PhaseFlip`
 - `AmplitudeDamping`
 - `PhaseDamping`
-- `DepolarizingChannel`
+- `Depolarizing`
 with values between $0$ and $1$.
+Additionally, a `GateError` can be applied, which controls the variance of a Gaussian distribution with zero mean applied on the input vector.
 
 This will apply the corresponding noise in each layer with the provided factor.
 

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -71,8 +71,13 @@ class Circuit(ABC):
 
 
 class Gates:
-    rng = np.random.default_rng(1000)
+    rng = None
 
+    @staticmethod
+    def init_rng(seed: int):
+        Gates.rng = np.random.default_rng(seed)
+
+    @staticmethod
     def Noise(
         wires: Union[int, List[int]], noise_params: Optional[Dict[str, float]] = None
     ) -> None:
@@ -100,13 +105,10 @@ class Gates:
             for wire in wires:
                 qml.BitFlip(noise_params.get("BitFlip", 0.0), wires=wire)
                 qml.PhaseFlip(noise_params.get("PhaseFlip", 0.0), wires=wire)
-                qml.DepolarizingChannel(
-                    noise_params.get("Depolarizing", 0.0), wires=wire
-                )
+                qml.DepolarizingChannel(noise_params.get("Depolarizing", 0.0), wires=wire)
 
-    def GateError(
-        w: np.ndarray, noise_params: Optional[Dict[str, float]] = None
-    ) -> np.ndarray:
+    @staticmethod
+    def GateError(w: np.ndarray, noise_params: Optional[Dict[str, float]] = None) -> np.ndarray:
         """
         Applies a gate error to the given rotation angle(s).
 
@@ -128,10 +130,13 @@ class Gates:
         np.ndarray
             The modified rotation angle(s) after applying the gate error.
         """
+        if Gates.rng is None:
+            raise ValueError("Gates.rng is not initialised, yet. Forgot to call" "`Gates.init_rng(seed)`?")
         if noise_params is not None:
             w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
         return w
 
+    @staticmethod
     def Rot(phi, theta, omega, wires, noise_params=None):
         """
         Applies a rotation gate to the given wires and adds `Noise`
@@ -156,6 +161,8 @@ class Gates:
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        if Gates.rng is None:
+            raise ValueError("Gates.rng is not initialised, yet. Forgot to call" "`Gates.init_rng(seed)`?")
         if noise_params is not None and "GateError" in noise_params:
             phi += Gates.rng.normal(0, noise_params["GateError"])
             theta += Gates.rng.normal(0, noise_params["GateError"])
@@ -163,6 +170,7 @@ class Gates:
         qml.Rot(phi, theta, omega, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def RX(w, wires, noise_params=None):
         """
         Applies a rotation around the X axis to the given wires and adds `Noise`
@@ -186,6 +194,7 @@ class Gates:
         qml.RX(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def RY(w, wires, noise_params=None):
         """
         Applies a rotation around the Y axis to the given wires and adds `Noise`
@@ -210,6 +219,7 @@ class Gates:
         qml.RY(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def RZ(w, wires, noise_params=None):
         """
         Applies a rotation around the Z axis to the given wires and adds `Noise`
@@ -233,6 +243,7 @@ class Gates:
         qml.RZ(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CRX(w, wires, noise_params=None):
         """
         Applies a controlled rotation around the X axis to the given wires
@@ -258,6 +269,7 @@ class Gates:
         qml.CRX(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CRY(w, wires, noise_params=None):
         """
         Applies a controlled rotation around the Y axis to the given wires
@@ -283,6 +295,7 @@ class Gates:
         qml.CRY(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CRZ(w, wires, noise_params=None):
         """
         Applies a controlled rotation around the Z axis to the given wires
@@ -304,11 +317,14 @@ class Gates:
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        if Gates.rng is None:
+            raise ValueError("Gates.rng is not initialised, yet. Forgot to call" "`Gates.init_rng(seed)`?")
         if noise_params is not None and "GateError" in noise_params:
             w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
         qml.CRZ(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CX(wires, noise_params=None):
         """
         Applies a controlled NOT gate to the given wires and adds `Noise`
@@ -330,6 +346,7 @@ class Gates:
         qml.CNOT(wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CY(wires, noise_params=None):
         """
         Applies a controlled Y gate to the given wires and adds `Noise`
@@ -351,6 +368,7 @@ class Gates:
         qml.CY(wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def CZ(wires, noise_params=None):
         """
         Applies a controlled Z gate to the given wires and adds `Noise`
@@ -372,6 +390,7 @@ class Gates:
         qml.CZ(wires=wires)
         Gates.Noise(wires, noise_params)
 
+    @staticmethod
     def H(wires, noise_params=None):
         """
         Applies a Hadamard gate to the given wires and adds `Noise`

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -71,7 +71,7 @@ class Circuit(ABC):
 
 
 class Gates:
-    rng = None
+    rng = np.random.default_rng()
 
     @staticmethod
     def init_rng(seed: int):

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import pennylane.numpy as np
 import pennylane as qml
 
-from typing import List
+from typing import List, Union, Dict
 
 import logging
 
@@ -73,7 +73,9 @@ class Circuit(ABC):
 class Gates:
     rng = np.random.default_rng(1000)
 
-    def Noise(wires, noise_params=None):
+    def Noise(
+        wires: Union[int, List[int]], noise_params: Optional[Dict[str, float]] = None
+    ) -> None:
         """
         Applies noise to the given wires.
 
@@ -102,7 +104,30 @@ class Gates:
                     noise_params.get("Depolarizing", 0.0), wires=wire
                 )
 
-    def GateError(w, noise_params=None):
+    def GateError(
+        w: np.ndarray, noise_params: Optional[Dict[str, float]] = None
+    ) -> np.ndarray:
+        """
+        Applies a gate error to the given rotation angle(s).
+
+        Parameters
+        ----------
+        w : np.ndarray
+            The rotation angle(s) in radians.
+        noise_params : Optional[Dict[str, float]]
+            A dictionary of noise parameters. The following noise gates are
+            supported:
+            - GateError: Applies a normal distribution error to the rotation
+            angle(s). The standard deviation of the noise is specified by
+            the "GateError" key in the dictionary.
+
+            All parameters are optional and default to 0.0 if not provided.
+
+        Returns
+        -------
+        np.ndarray
+            The modified rotation angle(s) after applying the gate error.
+        """
         if noise_params is not None:
             w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
         return w

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -71,6 +71,8 @@ class Circuit(ABC):
 
 
 class Gates:
+    rng = np.random.default_rng(1000)
+
     def Noise(wires, noise_params=None):
         """
         Applies noise to the given wires.
@@ -84,7 +86,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -97,8 +99,13 @@ class Gates:
                 qml.BitFlip(noise_params.get("BitFlip", 0.0), wires=wire)
                 qml.PhaseFlip(noise_params.get("PhaseFlip", 0.0), wires=wire)
                 qml.DepolarizingChannel(
-                    noise_params.get("DepolarizingChannel", 0.0), wires=wire
+                    noise_params.get("Depolarizing", 0.0), wires=wire
                 )
+
+    def GateError(w, noise_params=None):
+        if noise_params is not None:
+            w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
+        return w
 
     def Rot(phi, theta, omega, wires, noise_params=None):
         """
@@ -119,11 +126,15 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        if noise_params is not None and "GateError" in noise_params:
+            phi += Gates.rng.normal(0, noise_params["GateError"])
+            theta += Gates.rng.normal(0, noise_params["GateError"])
+            omega += Gates.rng.normal(0, noise_params["GateError"])
         qml.Rot(phi, theta, omega, wires=wires)
         Gates.Noise(wires, noise_params)
 
@@ -142,7 +153,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -165,11 +176,12 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
             given wires.
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        w = Gates.GateError(w, noise_params)
         qml.RY(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
@@ -188,7 +200,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -212,11 +224,12 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        w = Gates.GateError(w, noise_params)
         qml.CRX(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
@@ -236,11 +249,12 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        w = Gates.GateError(w, noise_params)
         qml.CRY(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
@@ -260,11 +274,13 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
             given wires.
 
             All parameters are optional and default to 0.0 if not provided.
         """
+        if noise_params is not None and "GateError" in noise_params:
+            w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
         qml.CRZ(w, wires=wires)
         Gates.Noise(wires, noise_params)
 
@@ -281,7 +297,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -302,7 +318,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -323,7 +339,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.
@@ -344,7 +360,7 @@ class Gates:
             supported:
             - BitFlip: Applies a bit flip error to the given wires.
             - PhaseFlip: Applies a phase flip error to the given wires.
-            - DepolarizingChannel: Applies a depolarizing channel error to the
+            - Depolarizing: Applies a depolarizing channel error to the
               given wires.
 
             All parameters are optional and default to 0.0 if not provided.

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -75,6 +75,14 @@ class Gates:
 
     @staticmethod
     def init_rng(seed: int):
+        """
+        Initializes the random number generator with the given seed.
+
+        Parameters
+        ----------
+        seed : int
+            The seed for the random number generator.
+        """
         Gates.rng = np.random.default_rng(seed)
 
     @staticmethod
@@ -134,11 +142,6 @@ class Gates:
         np.ndarray
             The modified rotation angle(s) after applying the gate error.
         """
-        if Gates.rng is None:
-            raise ValueError(
-                "Gates.rng is not initialised, yet. Forgot to call\
-                `Gates.init_rng(seed)`?"
-            )
         if noise_params is not None:
             w += Gates.rng.normal(0, noise_params["GateError"], w.shape)
         return w
@@ -168,11 +171,6 @@ class Gates:
 
             All parameters are optional and default to 0.0 if not provided.
         """
-        if Gates.rng is None:
-            raise ValueError(
-                "Gates.rng is not initialised, yet. Forgot to call\
-                `Gates.init_rng(seed)`?"
-            )
         if noise_params is not None and "GateError" in noise_params:
             phi += Gates.rng.normal(0, noise_params["GateError"])
             theta += Gates.rng.normal(0, noise_params["GateError"])

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -65,7 +65,8 @@ class Model:
             shots (Optional[int], optional): The number of shots to use for
                 the quantum device. Defaults to None.
             random_seed (int, optional): seed for the random number generator
-                in initialization is "random", Defaults to 1000.
+                in initialization is "random" and for random noise parameters.
+                Defaults to 1000.
 
         Returns:
             None
@@ -97,6 +98,9 @@ class Model:
             )()
         else:
             self.pqc = circuit_type()
+
+        # Initialize rng in Gates
+        Gates.init_rng(random_seed)
 
         # Initialize encoding
         # first check if we have a str, list or callable

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -186,6 +186,15 @@ class Model:
         """
         if value is not None and all(np == 0.0 for np in value.values()):
             value = None
+
+        if value is not None:
+            value.setdefault("BitFlip", 0.0)
+            value.setdefault("PhaseFlip", 0.0)
+            value.setdefault("Depolarizing", 0.0)
+            value.setdefault("AmplitudeDamping", 0.0)
+            value.setdefault("PhaseDamping", 0.0)
+            value.setdefault("GateError", 0.0)
+
         self._noise_params = value
 
     @property

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -184,9 +184,11 @@ class Model:
         Returns:
             None
         """
+        # set to None if only zero values provided
         if value is not None and all(np == 0.0 for np in value.values()):
             value = None
 
+        # set default values
         if value is not None:
             value.setdefault("BitFlip", 0.0)
             value.setdefault("PhaseFlip", 0.0)
@@ -194,6 +196,20 @@ class Model:
             value.setdefault("AmplitudeDamping", 0.0)
             value.setdefault("PhaseDamping", 0.0)
             value.setdefault("GateError", 0.0)
+
+        # check if there are any keys not supported
+        for key in value.keys():
+            if key not in [
+                "BitFlip",
+                "PhaseFlip",
+                "Depolarizing",
+                "AmplitudeDamping",
+                "PhaseDamping",
+                "GateError",
+            ]:
+                warnings.warn(
+                    f"Noise type {key} is not supported by this package", UserWarning
+                )
 
         self._noise_params = value
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -173,7 +173,7 @@ class Model:
         return self._noise_params
 
     @noise_params.setter
-    def noise_params(self, value: Optional[Dict[str, float]]) -> None:
+    def noise_params(self, kvs: Optional[Dict[str, float]]) -> None:
         """
         Sets the noise parameters of the model.
 
@@ -185,33 +185,34 @@ class Model:
             None
         """
         # set to None if only zero values provided
-        if value is not None and all(np == 0.0 for np in value.values()):
-            value = None
+        if kvs is not None and all(np == 0.0 for np in kvs.values()):
+            kvs = None
 
         # set default values
-        if value is not None:
-            value.setdefault("BitFlip", 0.0)
-            value.setdefault("PhaseFlip", 0.0)
-            value.setdefault("Depolarizing", 0.0)
-            value.setdefault("AmplitudeDamping", 0.0)
-            value.setdefault("PhaseDamping", 0.0)
-            value.setdefault("GateError", 0.0)
+        if kvs is not None:
+            kvs.setdefault("BitFlip", 0.0)
+            kvs.setdefault("PhaseFlip", 0.0)
+            kvs.setdefault("Depolarizing", 0.0)
+            kvs.setdefault("AmplitudeDamping", 0.0)
+            kvs.setdefault("PhaseDamping", 0.0)
+            kvs.setdefault("GateError", 0.0)
 
-        # check if there are any keys not supported
-        for key in value.keys():
-            if key not in [
-                "BitFlip",
-                "PhaseFlip",
-                "Depolarizing",
-                "AmplitudeDamping",
-                "PhaseDamping",
-                "GateError",
-            ]:
-                warnings.warn(
-                    f"Noise type {key} is not supported by this package", UserWarning
-                )
+            # check if there are any keys not supported
+            for key in kvs.keys():
+                if key not in [
+                    "BitFlip",
+                    "PhaseFlip",
+                    "Depolarizing",
+                    "AmplitudeDamping",
+                    "PhaseDamping",
+                    "GateError",
+                ]:
+                    warnings.warn(
+                        f"Noise type {key} is not supported by this package",
+                        UserWarning,
+                    )
 
-        self._noise_params = value
+        self._noise_params = kvs
 
     @property
     def execution_type(self) -> str:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -310,10 +310,6 @@ def test_ansaetze() -> None:
     ansatz_cases = Ansaetze.get_available()
 
     for ansatz in ansatz_cases:
-        # Skipping Circuit_15, as it is not yet correctly implemented (yet)
-        if ansatz.__name__ == "Circuit_15":
-            continue
-
         logger.info(f"Testing Ansatz: {ansatz.__name__}")
         model = Model(
             n_qubits=4,
@@ -329,11 +325,12 @@ def test_ansaetze() -> None:
             model.params,
             inputs=None,
             noise_params={
+                "GateError": 0.1,
                 "BitFlip": 0.1,
                 "PhaseFlip": 0.2,
                 "AmplitudeDamping": 0.3,
                 "PhaseDamping": 0.4,
-                "DepolarizingChannel": 0.5,
+                "Depolarizing": 0.5,
             },
             cache=False,
             execution_type="density",
@@ -376,11 +373,10 @@ def test_ansaetze() -> None:
         model.params,
         inputs=None,
         noise_params={
-            "BitFlip": 0.1,
+            "GateError": 0.1,
             "PhaseFlip": 0.2,
             "AmplitudeDamping": 0.3,
-            "PhaseDamping": 0.4,
-            "DepolarizingChannel": 0.5,
+            "Depolarizing": 0.5,
         },
         cache=False,
         execution_type="density",
@@ -489,7 +485,7 @@ def test_local_state() -> None:
                 "PhaseFlip": 0.2,
                 "AmplitudeDamping": 0.3,
                 "PhaseDamping": 0.4,
-                "DepolarizingChannel": 0.5,
+                "Depolarizing": 0.5,
             },
             "execution_type": "density",
         },

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -382,6 +382,17 @@ def test_ansaetze() -> None:
         execution_type="density",
     )
 
+    with pytest.warns(UserWarning):
+        _ = model(
+            model.params,
+            inputs=None,
+            noise_params={
+                "UnsupportedNoise": 0.1,
+            },
+            cache=False,
+            execution_type="density",
+        )
+
 
 @pytest.mark.unittest
 def test_available_ansaetze() -> None:


### PR DESCRIPTION
This PR adds Gate error as additional error type. For this reason, the `Gates` class got a new property `rng` which is being used to draw samples.
Also the `DepolarizingChannel` noise is renamed to `Depolarizing` and a warning is introduced if provided noise type is not supported.
Tests and documentation adapted accordingly.