### PR TITLE
New types of noise

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,10 +87,21 @@ Noise can be added to the model by providing a `noise_params` argument, when cal
 - `AmplitudeDamping`
 - `PhaseDamping`
 - `Depolarizing`
+- `StatePreparation`
+- `Measurement`
+
 with values between $0$ and $1$.
 Additionally, a `GateError` can be applied, which controls the variance of a Gaussian distribution with zero mean applied on the input vector.
 
 This will apply the corresponding noise in each layer with the provided factor.
+
+Furthermore, `ThermalRelaxation` can be applied. Instead of the probability, the entry for this type of error consists of another dict with the keys:
+- `T1`: The relative T1 relaxation time (a typical value might be 180 (us))
+- `T2`: The relative T2 relaxation time (a typical value might be 100 (us))
+- `t_factor`: The relative gate time (a typical value might be 0.018 (us))
+The units can be ignored as we are only interested in relative times, above values might belong to some superconducting system.
+Note that T2 is required to be max. 2 T1.
+Based on `t_factor` and the circuit depth the execution time is esimated, and therefore the influence of thermal relaxation over time.
 
 ## Caching
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,7 +96,7 @@ Noise can be added to the model by providing a `noise_params` argument, when cal
 with values between $0$ and $1$.
 Additionally, a `GateError` can be applied, which controls the variance of a Gaussian distribution with zero mean applied on the input vector.
 
-While `BitFlip`, `PhaseFlip` and `GateError`s are applied on each gate, `AmplitudeDamping`, `PhaseDamping`, `Depolarizing`, `StatePreparation` and `Measurement` are applied on the whole circuit.
+While `BitFlip`, `PhaseFlip`, `Depolarizing` and `GateError`s are applied on each gate, `AmplitudeDamping`, `PhaseDamping`, `StatePreparation` and `Measurement` are applied on the whole circuit.
 
 Furthermore, `ThermalRelaxation` can be applied. 
 Instead of the probability, the entry for this type of error consists of another dict with the keys:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,6 +55,7 @@ The encoding can be set when instantiating the model with the `encoding` argumen
 
 The default encoding is "RX" which will result in a single RX rotation per qubit.
 Other options are:
+
 - Any callable such as `Gates.RX`
 - A list of callables such as `[Gates.RX, Gates.RY]`
 - A string such as `"RX"` that will result in a single RX rotation per qubit
@@ -75,6 +76,7 @@ This is usually helpful, if you want to perform a n-local measurement over all q
 ## Execution Type
 
 Our model be simulated in different ways by setting the `execution_type` property, when calling the model, to:
+
 - `exp_val`: Returns the expectation value between $0$ and $1$
 - `density`: Calculates the density matrix
 - `probs`: Simulates the model with the number of shots, set by `model.shots`
@@ -82,6 +84,7 @@ Our model be simulated in different ways by setting the `execution_type` propert
 ## Noise
 
 Noise can be added to the model by providing a `noise_params` argument, when calling the model, which is a dictionary with following keys
+
 - `BitFlip`
 - `PhaseFlip`
 - `AmplitudeDamping`
@@ -93,21 +96,25 @@ Noise can be added to the model by providing a `noise_params` argument, when cal
 with values between $0$ and $1$.
 Additionally, a `GateError` can be applied, which controls the variance of a Gaussian distribution with zero mean applied on the input vector.
 
-This will apply the corresponding noise in each layer with the provided factor.
+While `BitFlip`, `PhaseFlip` and `GateError`s are applied on each gate, `AmplitudeDamping`, `PhaseDamping`, `Depolarizing`, `StatePreparation` and `Measurement` are applied on the whole circuit.
 
-Furthermore, `ThermalRelaxation` can be applied. Instead of the probability, the entry for this type of error consists of another dict with the keys:
-- `T1`: The relative T1 relaxation time (a typical value might be 180 (us))
-- `T2`: The relative T2 relaxation time (a typical value might be 100 (us))
-- `t_factor`: The relative gate time (a typical value might be 0.018 (us))
+Furthermore, `ThermalRelaxation` can be applied. 
+Instead of the probability, the entry for this type of error consists of another dict with the keys:
+
+- `T1`: The relative T1 relaxation time (a typical value might be $180\mathrm{us}$)
+- `T2`: The relative T2 relaxation time (a typical value might be $100\mathrm{us}$)
+- `t_factor`: The relative gate time (a typical value might be $0.018\mathrm{us}$)
+
 The units can be ignored as we are only interested in relative times, above values might belong to some superconducting system.
-Note that T2 is required to be max. 2 T1.
-Based on `t_factor` and the circuit depth the execution time is esimated, and therefore the influence of thermal relaxation over time.
+Note that `T2` is required to be max. $2\times$`T1`.
+Based on `t_factor` and the circuit depth the execution time is estimated, and therefore the influence of thermal relaxation over time.
 
 ## Caching
 
 To speed up calculation, you can add `cache=True` when calling the model.
 The result of the model call will then be stored in a numpy format in a folder `.cache`.
 Each result is being identified by a md5 hash that is a representation of the following model properties:
+
 - number of qubits
 - number of layers
 - ansatz

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,12 +101,12 @@ While `BitFlip`, `PhaseFlip` and `GateError`s are applied on each gate, `Amplitu
 Furthermore, `ThermalRelaxation` can be applied. 
 Instead of the probability, the entry for this type of error consists of another dict with the keys:
 
-- `T1`: The relative T1 relaxation time (a typical value might be $180\mathrm{us}$)
-- `T2`: The relative T2 relaxation time (a typical value might be $100\mathrm{us}$)
-- `t_factor`: The relative gate time (a typical value might be $0.018\mathrm{us}$)
+- `t1`: The relative T1 relaxation time (a typical value might be $180\mathrm{us}$)
+- `t2`: The relative T2 relaxation time (a typical value might be $100\mathrm{us}$)
+- `t_factor`: The relative gate time factor (a typical value might be $0.018\mathrm{us}$)
 
 The units can be ignored as we are only interested in relative times, above values might belong to some superconducting system.
-Note that `T2` is required to be max. $2\times$`T1`.
+Note that `t2` is required to be max. $2\times$`t1`.
 Based on `t_factor` and the circuit depth the execution time is estimated, and therefore the influence of thermal relaxation over time.
 
 ## Caching

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import warnings
 from autograd.numpy import numpy_boxes
+from copy import deepcopy
 
 from qml_essentials.ansaetze import Gates, Ansaetze, Circuit
 
@@ -72,7 +73,7 @@ class Model:
             None
         """
         # Initialize default parameters needed for circuit evaluation
-        self.noise_params: Optional[Dict[str, float]] = None
+        self.noise_params: Optional[Dict[str, Union[float, Dict[str, float]]]] = None
         self.execution_type: Optional[str] = "expval"
         self.shots = shots
 
@@ -166,7 +167,7 @@ class Model:
         )
 
     @property
-    def noise_params(self) -> Optional[Dict[str, float]]:
+    def noise_params(self) -> Optional[Dict[str, Union[float, Dict[str, float]]]]:
         """
         Gets the noise parameters of the model.
 
@@ -177,13 +178,26 @@ class Model:
         return self._noise_params
 
     @noise_params.setter
-    def noise_params(self, kvs: Optional[Dict[str, float]]) -> None:
+    def noise_params(
+        self, kvs: Optional[Dict[str, Union[float, Dict[str, float]]]]
+    ) -> None:
         """
         Sets the noise parameters of the model.
 
+        Typically a "noise parameter" refers to the error probability.
+        ThermalRelaxation is a special case, and supports a dict as value with
+        structure:
+            "ThermalRelaxation":
+            {
+                "T1": 2000, # relative t1 time.
+                "T2": 1000, # relative t2 time
+                "t_factor" 1: # relative gate time factor
+            },
+
         Args:
-            value (Optional[Dict[str, float]]): A dictionary of noise parameters.
-                If all values are 0.0, the noise parameters are set to None.
+            value (Optional[Dict[str, Union[float, Dict[str, float]]]]): A
+            dictionary of noise parameters. If all values are 0.0, the noise
+            parameters are set to None.
 
         Returns:
             None
@@ -200,6 +214,7 @@ class Model:
             kvs.setdefault("AmplitudeDamping", 0.0)
             kvs.setdefault("PhaseDamping", 0.0)
             kvs.setdefault("GateError", 0.0)
+            kvs.setdefault("ThermalRelaxation", 0.0)
 
             # check if there are any keys not supported
             for key in kvs.keys():
@@ -210,11 +225,37 @@ class Model:
                     "AmplitudeDamping",
                     "PhaseDamping",
                     "GateError",
+                    "ThermalRelaxation",
                 ]:
                     warnings.warn(
                         f"Noise type {key} is not supported by this package",
                         UserWarning,
                     )
+
+            # check valid params for thermal relaxation noise channel
+            tr_params = kvs["ThermalRelaxation"]
+            if isinstance(tr_params, dict):
+                tr_params.setdefault("T1", 0.0)
+                tr_params.setdefault("T2", 0.0)
+                tr_params.setdefault("t_factor", 0.0)
+                for k in tr_params.keys():
+                    if k not in [
+                        "T1",
+                        "T2",
+                        "t_factor",
+                    ]:
+                        warnings.warn(
+                            f"Thermal Relaxation parameter {k} is not supported "
+                            f"by this package",
+                            UserWarning,
+                        )
+                if not all(tr_params.values()) or tr_params["T2"] > 2 * tr_params["T1"]:
+                    warnings.warn(
+                        "Received invalid values for Thermal Relaxation noise "
+                        "parameter. Thermal relaxation is not applied!",
+                        UserWarning,
+                    )
+                    kvs["ThermalRelaxation"] = 0.0
 
         self._noise_params = kvs
 
@@ -354,7 +395,7 @@ class Model:
         inputs: np.ndarray,
         data_reupload: bool,
         enc: Union[Callable, List[Callable]],
-        noise_params: Optional[np.ndarray] = None,
+        noise_params: Optional[Dict[str, Union[float, Dict[str, float]]]] = None,
     ) -> None:
         """
         Creates an AngleEncoding using RX gates
@@ -421,11 +462,7 @@ class Model:
             self.pqc(params[-1], self.n_qubits, noise_params=self.noise_params)
 
         if self.noise_params is not None:
-            for q in range(self.n_qubits):
-                qml.AmplitudeDamping(
-                    self.noise_params.get("AmplitudeDamping", 0.0), wires=q
-                )
-                qml.PhaseDamping(self.noise_params.get("PhaseDamping", 0.0), wires=q)
+            self._apply_general_noise()
 
         # run mixed simualtion and get density matrix
         if self.execution_type == "density":
@@ -461,6 +498,33 @@ class Model:
         else:
             raise ValueError(f"Invalid execution_type: {self.execution_type}.")
 
+    def _apply_general_noise(self) -> None:
+        """
+        Applies general types of noise the full circuit (in contrast to gate
+        errors, applied directly at gate level, see Gates.Noise).
+
+        Possible types of noise are:
+            - AmplitudeDamping (specified through probability)
+            - PhaseDamping (specified through probability)
+            - ThermalRelaxation (specified through a dict, containing keys
+                                 "T1", "T2", "t_factor")
+        """
+        amp_damp = self.noise_params.get("AmplitudeDamping", 0.0)
+        phase_damp = self.noise_params.get("PhaseDamping", 0.0)
+        thermal_relax = self.noise_params.get("ThermalRelaxation", 0.0)
+        for q in range(self.n_qubits):
+            if amp_damp > 0:
+                qml.AmplitudeDamping(amp_damp, wires=q)
+            if phase_damp > 0:
+                qml.PhaseDamping(phase_damp, wires=q)
+            if isinstance(thermal_relax, dict):
+                t1 = thermal_relax["T1"]
+                t2 = thermal_relax["T2"]
+                t_factor = thermal_relax["t_factor"]
+                circuit_depth = self.get_circuit_depth()
+                tg = circuit_depth * t_factor
+                qml.ThermalRelaxationError(1.0, t1, t2, tg, q)
+
     def _draw(self, inputs=None, figure=False) -> None:
         if not isinstance(self.circuit, qml.QNode):
             # TODO: throws strange argument error if not catched
@@ -488,7 +552,7 @@ class Model:
         self,
         params: Optional[np.ndarray] = None,
         inputs: Optional[np.ndarray] = None,
-        noise_params: Optional[Dict[str, float]] = None,
+        noise_params: Optional[Dict[str, Union[float, Dict[str, float]]]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
         force_mean: Optional[bool] = False,
@@ -569,7 +633,7 @@ class Model:
         self,
         params: Optional[np.ndarray] = None,
         inputs: Optional[np.ndarray] = None,
-        noise_params: Optional[Dict[str, float]] = None,
+        noise_params: Optional[Dict[str, Union[float, Dict[str, float]]]] = None,
         cache: Optional[bool] = False,
         execution_type: Optional[str] = None,
         force_mean: Optional[bool] = False,
@@ -713,7 +777,9 @@ class Model:
                 about the circuit size and gate statistics.
         """
         inputs = self._inputs_validation(inputs)
-        return qml.specs(self.circuit)(self.params, inputs)
+        spec_model = deepcopy(self)
+        spec_model.noise_params = None  # remove noise
+        return qml.specs(spec_model.circuit)(self.params, inputs)
 
     def get_circuit_depth(self, inputs: Optional[np.ndarray] = None) -> int:
         """

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -699,3 +699,31 @@ class Model:
             np.save(file_path, result)
 
         return result
+
+    def get_specs(self, inputs: Optional[np.ndarray] = None) -> dict:
+        """
+        Get pennylane specs for the model.
+
+        Args:
+            inputs (Optional[np.ndarray]): The inputs, with which to call the
+                circuit. Defaults to None.
+
+        Returns:
+            dict: Dictionary of specs. The key "resources" contains information
+                about the circuit size and gate statistics.
+        """
+        inputs = self._inputs_validation(inputs)
+        return qml.specs(self.circuit)(self.params, inputs)
+
+    def get_circuit_depth(self, inputs: Optional[np.ndarray] = None) -> int:
+        """
+        Obtain circuit depth for the model
+
+        Args:
+            inputs (Optional[np.ndarray]): The inputs, with which to call the
+                circuit. Defaults to None.
+
+        Returns:
+            int: Circuit depth (longest path of gates in circuit.)
+        """
+        return self.get_specs(inputs)["resources"].depth

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -189,8 +189,8 @@ class Model:
         structure:
             "ThermalRelaxation":
             {
-                "T1": 2000, # relative t1 time.
-                "T2": 1000, # relative t2 time
+                "t1": 2000, # relative t1 time.
+                "t2": 1000, # relative t2 time
                 "t_factor" 1: # relative gate time factor
             },
 
@@ -214,7 +214,7 @@ class Model:
             kvs.setdefault("AmplitudeDamping", 0.0)
             kvs.setdefault("PhaseDamping", 0.0)
             kvs.setdefault("GateError", 0.0)
-            kvs.setdefault("ThermalRelaxation", 0.0)
+            kvs.setdefault("ThermalRelaxation", None)
             kvs.setdefault("StatePreparation", 0.0)
             kvs.setdefault("Measurement", 0.0)
 
@@ -239,13 +239,13 @@ class Model:
             # check valid params for thermal relaxation noise channel
             tr_params = kvs["ThermalRelaxation"]
             if isinstance(tr_params, dict):
-                tr_params.setdefault("T1", 0.0)
-                tr_params.setdefault("T2", 0.0)
+                tr_params.setdefault("t1", 0.0)
+                tr_params.setdefault("t2", 0.0)
                 tr_params.setdefault("t_factor", 0.0)
                 for k in tr_params.keys():
                     if k not in [
-                        "T1",
-                        "T2",
+                        "t1",
+                        "t2",
                         "t_factor",
                     ]:
                         warnings.warn(
@@ -253,7 +253,7 @@ class Model:
                             f"by this package",
                             UserWarning,
                         )
-                if not all(tr_params.values()) or tr_params["T2"] > 2 * tr_params["T1"]:
+                if not all(tr_params.values()) or tr_params["t2"] > 2 * tr_params["t1"]:
                     warnings.warn(
                         "Received invalid values for Thermal Relaxation noise "
                         "parameter. Thermal relaxation is not applied!",
@@ -523,7 +523,7 @@ class Model:
             - AmplitudeDamping (specified through probability)
             - PhaseDamping (specified through probability)
             - ThermalRelaxation (specified through a dict, containing keys
-                                 "T1", "T2", "t_factor")
+                                 "t1", "t2", "t_factor")
             - Measurement (specified through probability)
         """
         amp_damp = self.noise_params.get("AmplitudeDamping", 0.0)
@@ -538,8 +538,8 @@ class Model:
             if meas > 0:
                 qml.BitFlip(meas, wires=q)
             if isinstance(thermal_relax, dict):
-                t1 = thermal_relax["T1"]
-                t2 = thermal_relax["T2"]
+                t1 = thermal_relax["t1"]
+                t2 = thermal_relax["t2"]
                 t_factor = thermal_relax["t_factor"]
                 circuit_depth = self.get_circuit_depth()
                 tg = circuit_depth * t_factor

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -331,6 +331,7 @@ def test_ansaetze() -> None:
                 "AmplitudeDamping": 0.3,
                 "PhaseDamping": 0.4,
                 "Depolarizing": 0.5,
+                "ThermalRelaxation": {"T1": 2000.0, "T2": 1000.0, "t_factor": 1},
             },
             cache=False,
             execution_type="density",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -332,6 +332,8 @@ def test_ansaetze() -> None:
                 "PhaseDamping": 0.4,
                 "Depolarizing": 0.5,
                 "ThermalRelaxation": {"T1": 2000.0, "T2": 1000.0, "t_factor": 1},
+                "StatePreparation": 0.1,
+                "Measurement": 0.1,
             },
             cache=False,
             execution_type="density",


### PR DESCRIPTION
This PR adds thermal relaxation and SPAM noise, as new general types of noise, ie. we have three new noise types:
- StatePreparation: Bitflip on each qubit at the beginning of the circuit
- Measurement: Bitflip on each qubit at the end of the circuit
- ThermalRelaxation: gets applied at the end of the circuit and depends on three parameters: T1, T2, f_factor (maybe re-word the latter). Generally the follwing applies:
   - The smaller the relaxation times T1, T2, the noisyer
   - The larger the f_factor (related to gate time), and the circuit depth, the noisyer

Additionally, a circuit spec function for the circuit depth is added