### PR TITLE
Encoding gates

### DIFF
--- a/docs/coefficients.md
+++ b/docs/coefficients.md
@@ -92,7 +92,7 @@ X_shift, X_freq_shift = Coefficients.get_spectrum(model_fct, mfs=2, mts=3, shift
 
 Note that, as the frequencies change with the `mts` argument, we have to take that into account when calculating the frequencies with the last call.
 
-Feel free to checkout our [jupyter notebook](https://github.com/quantum-machine-learning/qml_essentials/blob/main/docs/notebooks/coefficients.ipynb) if you would like to play around with this.
+Feel free to checkout our [jupyter notebook](https://github.com/cirKITers/qml-essentials/blob/main/docs/coefficients.ipynb) if you would like to play around with this.
 
 A sidenote on the performance; Increasing the `mts` value effectively increases the input lenght that goes into the model.
 This means that `mts=2` will require twice the time to compute, which will be very noticable when running noisy simulations.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,29 @@ You can calculate the [Expressibility](expressibility.md) or [Entangling Capabil
 You can also provide a custom circuit, by instantiating from the `Circuit` class in `qml_essentials.ansaetze.Circuit`.
 See page [*Ansaetze*](ansaetze.md) for more details and a list of available Ansatzes that we provide with this package.
 
+## Data-Reuploading
+
+This idea is one of the core features of our framework and builds upon the work by [*Schuld et al. (2020)*](https://arxiv.org/abs/2008.08605).
+Essentially it allows us to represent a quantum circuit as a truncated Fourier series which is a powerfull feature that enables the model to mimic arbitrary non-linear functions.
+The number of frequencies that the model can represent is constrained by the number of data encoding steps within the circuit.
+
+Typically, there is a reuploading step after each layer and on each qubit (`data_reupload=True`).
+However, our package also allows you to specify and array with the number of rows representing the qubits and number of columns representing the layers.
+Then a `1` means that encoding is applied at the corresponding position within the circuit.
+
+In the following example, the model has two reuploading steps (`model.degree` = 2) although it would be capable of representing four frequencies:
+
+```python
+model = Model(
+    n_qubits=2,
+    n_layers=2,
+    circuit_type="Hardware_Efficient",
+    data_reupload=[[1, 0], [0, 1]],
+)
+```
+
+Checkout the [*Coefficients*](coefficients.md) page for more details on how you can visualize such a model using tools from signal analysis.
+
 ## Parameter Initialization
 
 The initialization strategy can be set when instantiating the model with the `initialization` argument.
@@ -64,6 +87,8 @@ Other options are:
 See page [*Ansaetze*](ansaetze.md) for more details regarding the `Gates` class.
 If a list of encodings is provided, the input is assumed to be multi-dimensional.
 Otherwise multiple inputs are treated as batches of inputs.
+
+If you want to visualize zero-valued encoding gates in the model, set `remove_zero_encoding` to `False` on instantiation.
 
 ## Output Shape
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -28,7 +28,7 @@ class Model:
         n_qubits: int,
         n_layers: int,
         circuit_type: Union[str, Circuit],
-        data_reupload: Union[bool, List] = True,
+        data_reupload: Union[bool, List[int]] = True,
         encoding: Union[str, Callable, List[str], List[Callable]] = Gates.RX,
         initialization: str = "random",
         initialization_domain: List[float] = [0, 2 * np.pi],
@@ -36,7 +36,7 @@ class Model:
         shots: Optional[int] = None,
         random_seed: int = 1000,
         as_pauli_circuit: bool = False,
-        remove_zero_encoding=True,
+        remove_zero_encoding: bool = True,
     ) -> None:
         """
         Initialize the quantum circuit model.
@@ -79,6 +79,8 @@ class Model:
                 et al. (https://doi.org/10.1103/PhysRevA.108.032406), which is
                 required for analytical Fourier coefficient computation.
                 Defaults to False.
+            remove_zero_encoding (bool, optional): whether to
+                remove the zero encoding from the circuit. Defaults to True.
 
         Returns:
             None

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -36,7 +36,7 @@ class Model:
         shots: Optional[int] = None,
         random_seed: int = 1000,
         as_pauli_circuit: bool = False,
-        remove_zero_encoding=False,
+        remove_zero_encoding=True,
     ) -> None:
         """
         Initialize the quantum circuit model.

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -86,6 +86,7 @@ class Model:
         self.noise_params: Optional[Dict[str, Union[float, Dict[str, float]]]] = None
         self.execution_type: Optional[str] = "expval"
         self.shots = shots
+        self.remove_zero_encoding = remove_zero_encoding
 
         if isinstance(output_qubit, list):
             assert (
@@ -440,7 +441,7 @@ class Model:
             None
         """
         # check for zero, because due to input validation, input cannot be none
-        if not inputs.any():
+        if self.remove_zero_encoding and not inputs.any():
             return
 
         if data_reupload:

--- a/tests/test_entanglement.py
+++ b/tests/test_entanglement.py
@@ -295,7 +295,6 @@ def test_entangling_measures() -> None:
             n_layers=test_case["n_layers"],
             circuit_type=test_case["circuit_type"],
             data_reupload=False,
-            initialization="random",
         )
 
         mw_meas = Entanglement.meyer_wallach(
@@ -303,7 +302,7 @@ def test_entangling_measures() -> None:
         )
 
         bell_meas = Entanglement.bell_measurements(
-            model, n_samples=2000, seed=1000, cache=False
+            deepcopy(model), n_samples=2000, seed=1000, cache=False
         )
 
         assert math.isclose(mw_meas, bell_meas, abs_tol=1e-5), (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -466,20 +466,37 @@ def test_multi_input() -> None:
             assert len(out.shape) == 0, "expected one elemental output for empty input"
 
 
-@pytest.mark.smoketest
+@pytest.mark.unittest
 def test_dru() -> None:
-    dru_cases = [False, True]
+    test_cases = [
+        {
+            "dru": False,
+            "degree": 1,
+        },
+        {
+            "dru": True,
+            "degree": 4,
+        },
+        {
+            "dru": [[True, False], [False, True]],
+            "degree": 2,
+        },
+    ]
 
-    for dru in dru_cases:
+    for test_case in test_cases:
         model = Model(
             n_qubits=2,
-            n_layers=1,
+            n_layers=2,
             circuit_type="Circuit_19",
-            data_reupload=dru,
+            data_reupload=test_case["dru"],
             initialization="random",
             output_qubit=0,
             shots=1024,
         )
+
+        assert (
+            model.degree == test_case["degree"]
+        ), f"Expected degree {test_case['degree']} but got {model.degree} for dru {test_case['dru']}"
 
         _ = model(
             model.params,
@@ -580,7 +597,7 @@ def test_local_and_global_meas() -> None:
             "execution_type": "expval",
             "output_qubit": -1,
             "shots": None,
-            "out_shape": (2,),
+            "out_shape": (2, 1),
             "warning": False,
         },
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -598,7 +598,7 @@ def test_local_and_global_meas() -> None:
             "execution_type": "expval",
             "output_qubit": -1,
             "shots": None,
-            "out_shape": (2, 1),
+            "out_shape": (2,),
             "warning": False,
         },
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -144,14 +144,26 @@ def test_parameters() -> None:
 @pytest.mark.smoketest
 def test_encoding() -> None:
     test_cases = [
-        {"encoding_unitary": Gates.RX, "type": Callable, "input": [0]},
+        {
+            "encoding_unitary": Gates.RX,
+            "type": Callable,
+            "input": [0],
+            "warning": False,
+        },
         {
             "encoding_unitary": [Gates.RX, Gates.RY],
             "type": List,
             "input": [[0, 0]],
+            "warning": False,
         },
-        {"encoding_unitary": "RX", "type": Callable, "input": [0]},
-        {"encoding_unitary": ["RX", "RY"], "type": List, "input": [[0, 0]]},
+        {"encoding_unitary": "RX", "type": Callable, "input": [0], "warning": False},
+        {
+            "encoding_unitary": ["RX", "RY"],
+            "type": List,
+            "input": [[0, 0]],
+            "warning": False,
+        },
+        {"encoding_unitary": ["RX", "RY"], "type": List, "input": [0], "warning": True},
     ]
 
     for test_case in test_cases:
@@ -160,12 +172,20 @@ def test_encoding() -> None:
             n_layers=1,
             circuit_type="Circuit_19",
             encoding=test_case["encoding_unitary"],
-        )
-        _ = model(
-            model.params,
-            inputs=test_case["input"],
+            remove_zero_encoding=False,
         )
 
+        if test_case["warning"]:
+            with pytest.warns(UserWarning):
+                _ = model(
+                    model.params,
+                    inputs=test_case["input"],
+                )
+        else:
+            _ = model(
+                model.params,
+                inputs=test_case["input"],
+            )
         assert isinstance(model._enc, test_case["type"])
 
 
@@ -335,7 +355,7 @@ def test_ansaetze() -> None:
                 "AmplitudeDamping": 0.3,
                 "PhaseDamping": 0.4,
                 "Depolarizing": 0.5,
-                "ThermalRelaxation": {"T1": 2000.0, "T2": 1000.0, "t_factor": 1},
+                "ThermalRelaxation": {"t1": 2000.0, "t2": 1000.0, "t_factor": 1},
                 "StatePreparation": 0.1,
                 "Measurement": 0.1,
             },

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -496,7 +496,8 @@ def test_dru() -> None:
 
         assert (
             model.degree == test_case["degree"]
-        ), f"Expected degree {test_case['degree']} but got {model.degree} for dru {test_case['dru']}"
+        ), f"Expected degree {test_case['degree']} but got {model.degree}\
+            for dru {test_case['dru']}"
 
         _ = model(
             model.params,


### PR DESCRIPTION
This PR closes #94 by
- adding a flag to the initialization which toggles the removing of zero encoding gates

and closes #65 by
- allowing `data_reupload` being an array of values of size (layers x qubits) that determine where to apply data reuploading

Open tasks:
- [x] adjust documentation after changes are confirmed 