### PR TITLE
Estimation of Concentratable Entanglement from Bell basis measurements

### DIFF
--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -142,34 +142,20 @@ class Entanglement:
 
         def _bell_circuit(params, inputs, pulse_params=None, random_key=None, **kw):
             """Bell measurement circuit on 2*n qubits."""
-            # First copy on wires 0..n-1
-            model._variational(
-                params, inputs, pulse_params=pulse_params, random_key=random_key, **kw
+            from qml_essentials.tape import copy_to_tape
+
+            vari = lambda: model._variational(
+                params,
+                inputs,
+                pulse_params=pulse_params,
+                random_key=random_key,
+                **kw,
             )
 
-            # TODO: this is very user-unfriendly and we should find a better way
-
-            # Second copy on wires n..2n-1: record the tape then shift wires
-            from qml_essentials.tape import recording as _recording
-
-            with _recording() as shifted_tape:
-                model._variational(
-                    params,
-                    inputs,
-                    pulse_params=pulse_params,
-                    random_key=random_key,
-                    **kw,
-                )
-            for o in shifted_tape:
-                shifted_op = o.__class__.__new__(o.__class__)
-                shifted_op.__dict__.update(o.__dict__)
-                shifted_op._wires = [w + n for w in o.wires]
-                # Re-register on the active tape
-                from qml_essentials.tape import active_tape as _active_tape
-
-                tape = _active_tape()
-                if tape is not None:
-                    tape.append(shifted_op)
+            # First copy on wires 0..n-1
+            vari()
+            # Second copy on wires n..2n-1
+            copy_to_tape(vari, offset=n)
 
             # Bell measurement: CNOT + H
             for q in range(n):
@@ -513,30 +499,20 @@ class Entanglement:
             params, inputs, pulse_params=None, random_key=None, **kw
         ):
             """Swap-test circuit on 3*n qubits."""
-            from qml_essentials.tape import recording as _recording
-            from qml_essentials.tape import shift_and_append
+            from qml_essentials.tape import copy_to_tape
+
+            vari = lambda: model._variational(
+                params,
+                inputs,
+                pulse_params=pulse_params,
+                random_key=random_key,
+                **kw,
+            )
 
             # First copy on wires n..2n-1
-            with _recording() as copy1_tape:
-                model._variational(
-                    params,
-                    inputs,
-                    pulse_params=pulse_params,
-                    random_key=random_key,
-                    **kw,
-                )
-            shift_and_append(copy1_tape, n)
-
+            copy_to_tape(vari, offset=n)
             # Second copy on wires 2n..3n-1
-            with _recording() as copy2_tape:
-                model._variational(
-                    params,
-                    inputs,
-                    pulse_params=pulse_params,
-                    random_key=random_key,
-                    **kw,
-                )
-            shift_and_append(copy2_tape, 2 * n)
+            copy_to_tape(vari, offset=2 * n)
 
             # Swap test: H on ancilla register (wires 0..n-1)
             for i in range(n):
@@ -628,31 +604,21 @@ class Entanglement:
         def _bell_basis_measurement(
             params, inputs, pulse_params=None, random_key=None, **kw
         ):
-            """Swap-test circuit on 3*n qubits."""
-            from qml_essentials.tape import recording as _recording
-            from qml_essentials.tape import shift_and_append
+            """Bell-basis measurement circuit on 3*n qubits."""
+            from qml_essentials.tape import copy_to_tape
+
+            vari = lambda: model._variational(
+                params,
+                inputs,
+                pulse_params=pulse_params,
+                random_key=random_key,
+                **kw,
+            )
 
             # First copy on wires n..2n-1
-            with _recording() as copy1_tape:
-                model._variational(
-                    params,
-                    inputs,
-                    pulse_params=pulse_params,
-                    random_key=random_key,
-                    **kw,
-                )
-            shift_and_append(copy1_tape, n)
-
+            copy_to_tape(vari, offset=n)
             # Second copy on wires 2n..3n-1
-            with _recording() as copy2_tape:
-                model._variational(
-                    params,
-                    inputs,
-                    pulse_params=pulse_params,
-                    random_key=random_key,
-                    **kw,
-                )
-            shift_and_append(copy2_tape, 2 * n)
+            copy_to_tape(vari, offset=2 * n)
 
             for i in range(n):
                 op.CX(wires=[i, i + n])

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -144,13 +144,14 @@ class Entanglement:
             """Bell measurement circuit on 2*n qubits."""
             from qml_essentials.tape import copy_to_tape
 
-            vari = lambda: model._variational(
-                params,
-                inputs,
-                pulse_params=pulse_params,
-                random_key=random_key,
-                **kw,
-            )
+            def vari():
+                model._variational(
+                    params,
+                    inputs,
+                    pulse_params=pulse_params,
+                    random_key=random_key,
+                    **kw
+                )
 
             # First copy on wires 0..n-1
             vari()
@@ -501,13 +502,14 @@ class Entanglement:
             """Swap-test circuit on 3*n qubits."""
             from qml_essentials.tape import copy_to_tape
 
-            vari = lambda: model._variational(
-                params,
-                inputs,
-                pulse_params=pulse_params,
-                random_key=random_key,
-                **kw,
-            )
+            def vari():
+                model._variational(
+                    params,
+                    inputs,
+                    pulse_params=pulse_params,
+                    random_key=random_key,
+                    **kw
+                )
 
             # First copy on wires n..2n-1
             copy_to_tape(vari, offset=n)
@@ -607,13 +609,14 @@ class Entanglement:
             """Bell-basis measurement circuit on 3*n qubits."""
             from qml_essentials.tape import copy_to_tape
 
-            vari = lambda: model._variational(
-                params,
-                inputs,
-                pulse_params=pulse_params,
-                random_key=random_key,
-                **kw,
-            )
+            def vari():
+                model._variational(
+                    params,
+                    inputs,
+                    pulse_params=pulse_params,
+                    random_key=random_key,
+                    **kw,
+                )
 
             # First copy on wires 0..n-1
             copy_to_tape(vari, offset=0)
@@ -643,7 +646,8 @@ class Entanglement:
         # Construct observable for measuring CE
         CE_observable = op.Id([0, n]) + op.Operation([0, n], SWAP)
         for i in range(1, n):
-            CE_observable = CE_observable @ (op.Id([i, i + n]) + op.Operation([i, i + n], SWAP))
+            CE_observable = (CE_observable @
+                             (op.Id([i, i + n]) + op.Operation([i, i + n], SWAP)))
         CE_observable = (1/N) * CE_observable
 
         expvals = []

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -9,6 +9,8 @@ from qml_essentials.math import logm_v
 from qml_essentials.model import Model
 import logging
 
+from qml_essentials.operations import Hermitian
+
 log = logging.getLogger(__name__)
 
 
@@ -598,6 +600,130 @@ class Entanglement:
 
         log.debug(f"Variance of measure: {ent.var()}")
 
+        return float(ent.mean())
+
+
+    @staticmethod
+    def concentratable_entanglement_estimation(
+        model: Model,
+        n_samples: int,
+        random_key: Optional[jax.random.PRNGKey] = None,
+        scale: bool = False,
+        **kwargs: Any,
+    ) -> float:
+        """
+        Computes the concentratable entanglement of a given model.
+
+        This method utilizes the Concentratable Entanglement measure from
+        https://arxiv.org/abs/2104.06923.  The swap test is implemented
+        directly in yaqsi using a ``3 * n_qubits`` circuit.
+
+        Args:
+            model (Model): The quantum circuit model.
+            n_samples (int): The number of samples to compute the measure for.
+            random_key (Optional[jax.random.PRNGKey]): JAX random key for
+                parameter initialization. If None, uses the model's internal
+                random key.
+            scale (bool): Whether to scale the number of samples according to
+                the number of qubits.
+            **kwargs (Any): Additional keyword arguments for the model function.
+
+        Returns:
+            float: Entangling capability of the given circuit, guaranteed
+                to be between 0.0 and 1.0.
+        """
+        n = model.n_qubits
+        N = 2**n
+
+        if scale:
+            n_samples = N * n_samples
+
+        def _shift_and_append(tape_ops, offset):
+            """Re-register *tape_ops* on the active tape with wires shifted."""
+            from qml_essentials.tape import active_tape as _active_tape
+
+            current = _active_tape()
+            if current is None:
+                return
+            for o in tape_ops:
+                shifted = o.__class__.__new__(o.__class__)
+                shifted.__dict__.update(o.__dict__)
+                shifted._wires = [w + offset for w in o.wires]
+                current.append(shifted)
+
+        def _bell_basis_measurement(
+            params, inputs, pulse_params=None, random_key=None, **kw
+        ):
+            """Swap-test circuit on 3*n qubits."""
+            from qml_essentials.tape import recording as _recording
+
+            # First copy on wires n..2n-1
+            with _recording() as copy1_tape:
+                model._variational(
+                    params,
+                    inputs,
+                    pulse_params=pulse_params,
+                    random_key=random_key,
+                    **kw,
+                )
+            _shift_and_append(copy1_tape, n)
+
+            # Second copy on wires 2n..3n-1
+            with _recording() as copy2_tape:
+                model._variational(
+                    params,
+                    inputs,
+                    pulse_params=pulse_params,
+                    random_key=random_key,
+                    **kw,
+                )
+            _shift_and_append(copy2_tape, 2 * n)
+
+            for i in range(n):
+                op.CX(wires=[i, i + n])
+                op.H(wires=i)
+
+        bell_basis_script = ys.Script(f=_bell_basis_measurement, n_qubits=2 * n)
+
+        if n_samples is not None and n_samples > 0:
+            random_key = model.initialize_params(random_key, repeat=n_samples)
+        else:
+            if len(model.params.shape) <= 2:
+                model.params = model.params.reshape(1, *model.params.shape)
+            else:
+                log.info(f"Using sample size of model params: {model.params.shape[0]}")
+
+        params = model.params
+        inputs = model._inputs_validation(kwargs.get("inputs", None))
+        n_batch = params.shape[0]
+
+        # Construct observable for measuring CE
+        CE_observable = op.Id()
+        for i in range(n):
+            CE_observable = CE_observable @ (op.Id([i, i + n]) + op.SWAP([i, i + n]))
+
+        expvals = []
+        if n_batch > 1:
+            from qml_essentials.utils import safe_random_split
+
+            random_keys = safe_random_split(random_key, num=n_batch)
+            expvals = bell_basis_script.execute(
+                type="expval",
+                obs=[CE_observable],
+                args=(params, inputs, model.pulse_params, random_keys),
+                in_axes=(0, None, None, 0),
+                kwargs=kwargs,
+            )
+        else:
+            expvals = bell_basis_script.execute(
+                type="expval",
+                obs=[CE_observable],
+                args=(params, inputs, model.pulse_params, random_key),
+                kwargs=kwargs,
+            )
+
+        ent = 1 - expvals
+        log.debug(f"Variance of measure: {ent.var()}")
         return float(ent.mean())
 
 

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -638,8 +638,9 @@ class Entanglement:
         inputs = model._inputs_validation(kwargs.get("inputs", None))
         n_batch = params.shape[0]
 
+        # SWAP operator in Bell-basis
+        SWAP = jnp.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]])
         # Construct observable for measuring CE
-        SWAP = jnp.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]) # SWAP operator in Bell-basis
         CE_observable = op.Id([0, n]) + op.Operation([0, n], SWAP)
         for i in range(1, n):
             CE_observable = CE_observable @ (op.Id([i, i + n]) + op.Operation([i, i + n], SWAP))

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -509,24 +509,12 @@ class Entanglement:
         if scale:
             n_samples = N * n_samples
 
-        def _shift_and_append(tape_ops, offset):
-            """Re-register *tape_ops* on the active tape with wires shifted."""
-            from qml_essentials.tape import active_tape as _active_tape
-
-            current = _active_tape()
-            if current is None:
-                return
-            for o in tape_ops:
-                shifted = o.__class__.__new__(o.__class__)
-                shifted.__dict__.update(o.__dict__)
-                shifted._wires = [w + offset for w in o.wires]
-                current.append(shifted)
-
         def _swap_test_circuit(
             params, inputs, pulse_params=None, random_key=None, **kw
         ):
             """Swap-test circuit on 3*n qubits."""
             from qml_essentials.tape import recording as _recording
+            from qml_essentials.tape import shift_and_append
 
             # First copy on wires n..2n-1
             with _recording() as copy1_tape:
@@ -537,7 +525,7 @@ class Entanglement:
                     random_key=random_key,
                     **kw,
                 )
-            _shift_and_append(copy1_tape, n)
+            shift_and_append(copy1_tape, n)
 
             # Second copy on wires 2n..3n-1
             with _recording() as copy2_tape:
@@ -548,7 +536,7 @@ class Entanglement:
                     random_key=random_key,
                     **kw,
                 )
-            _shift_and_append(copy2_tape, 2 * n)
+            shift_and_append(copy2_tape, 2 * n)
 
             # Swap test: H on ancilla register (wires 0..n-1)
             for i in range(n):
@@ -602,7 +590,6 @@ class Entanglement:
 
         return float(ent.mean())
 
-
     @staticmethod
     def concentratable_entanglement_estimation(
         model: Model,
@@ -638,24 +625,12 @@ class Entanglement:
         if scale:
             n_samples = N * n_samples
 
-        def _shift_and_append(tape_ops, offset):
-            """Re-register *tape_ops* on the active tape with wires shifted."""
-            from qml_essentials.tape import active_tape as _active_tape
-
-            current = _active_tape()
-            if current is None:
-                return
-            for o in tape_ops:
-                shifted = o.__class__.__new__(o.__class__)
-                shifted.__dict__.update(o.__dict__)
-                shifted._wires = [w + offset for w in o.wires]
-                current.append(shifted)
-
         def _bell_basis_measurement(
             params, inputs, pulse_params=None, random_key=None, **kw
         ):
             """Swap-test circuit on 3*n qubits."""
             from qml_essentials.tape import recording as _recording
+            from qml_essentials.tape import shift_and_append
 
             # First copy on wires n..2n-1
             with _recording() as copy1_tape:
@@ -666,7 +641,7 @@ class Entanglement:
                     random_key=random_key,
                     **kw,
                 )
-            _shift_and_append(copy1_tape, n)
+            shift_and_append(copy1_tape, n)
 
             # Second copy on wires 2n..3n-1
             with _recording() as copy2_tape:
@@ -677,7 +652,7 @@ class Entanglement:
                     random_key=random_key,
                     **kw,
                 )
-            _shift_and_append(copy2_tape, 2 * n)
+            shift_and_append(copy2_tape, 2 * n)
 
             for i in range(n):
                 op.CX(wires=[i, i + n])
@@ -747,7 +722,7 @@ def sample_random_separable_states(
     """
     model = Model(n_qubits, 1, "No_Entangling", data_reupload=False)
     model.initialize_params(random_key, repeat=n_samples)
-    # explicitly set execution type because everything else won't work
+    # explicitly set execution type because anything else won't work
     sigmas = model(execution_type="density", inputs=None)
     if take_log:
         sigmas = logm_v(sigmas) / jnp.log(2.0 + 0j)

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -615,10 +615,10 @@ class Entanglement:
                 **kw,
             )
 
-            # First copy on wires n..2n-1
+            # First copy on wires 0..n-1
+            copy_to_tape(vari, offset=0)
+            # Second copy on wires n..2n-1
             copy_to_tape(vari, offset=n)
-            # Second copy on wires 2n..3n-1
-            copy_to_tape(vari, offset=2 * n)
 
             for i in range(n):
                 op.CX(wires=[i, i + n])
@@ -639,9 +639,11 @@ class Entanglement:
         n_batch = params.shape[0]
 
         # Construct observable for measuring CE
-        CE_observable = op.Id()
-        for i in range(n):
-            CE_observable = CE_observable @ (op.Id([i, i + n]) + op.SWAP([i, i + n]))
+        SWAP = jnp.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]) # SWAP operator in Bell-basis
+        CE_observable = op.Id([0, n]) + op.Operation([0, n], SWAP)
+        for i in range(1, n):
+            CE_observable = CE_observable @ (op.Id([i, i + n]) + op.Operation([i, i + n], SWAP))
+        CE_observable = (1/N) * CE_observable
 
         expvals = []
         if n_batch > 1:

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -295,12 +295,25 @@ class Operation:
         return op
 
     def __add__(self, other: "Operation") -> "Operation":
-        if sorted(self.wires) != sorted(other.wires):
-            raise ValueError(f"{self.name} can only be added to operations acting on same set of wires")
+        """Element-wise addition of two operations on the same wires.
 
-        # TODO: Check if this works
-        op = Operation(wires=self.wires, matrix=self.matrix + other.matrix, record=False)
-        self._update_tape_operation(op)
+        Returns:
+            A new :class:`Operation` whose matrix is the sum of both matrices.
+
+        Raises:
+            ValueError: If the wire sets differ.
+        """
+        if sorted(self.wires) != sorted(other.wires):
+            raise ValueError(
+                f"Can only add operations acting on the same set of wires, "
+                f"got {self.wires} and {other.wires}"
+            )
+
+        op = Operation(
+            wires=self.wires,
+            matrix=self.matrix + other.matrix,
+            record=False,
+        )
         return op
 
     def __matmul__(self, other: "Operation") -> "Operation":

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -294,6 +294,19 @@ class Operation:
 
         return op
 
+    def __add__(self, other: "Operation") -> "Operation":
+        if sorted(self.wires) != sorted(other.wires):
+            raise ValueError(f"{self.name} can only be added to operations acting on same set of wires")
+
+        # TODO: Check if this works
+        op = Operation(wires=self.wires, matrix=self.matrix + other.matrix, record=False)
+        self._update_tape_operation(op)
+        return op
+
+    def __matmul__(self, other: "Operation") -> "Operation":
+        # TODO: implement tensor product of operations
+        pass
+
     def lifted_matrix(self, n_qubits: int) -> jnp.ndarray:
         """Return the full ``2**n x 2**n`` matrix embedding this gate.
 
@@ -580,6 +593,20 @@ class S(Operation):
             wires: Qubit index or list of qubit indices this gate acts on.
         """
         super().__init__(wires=wires)
+
+class SWAP(Operation):
+    """SWAP gate."""
+
+    _matrix = jnp.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=_cdtype())
+    _num_wires = 2
+
+    def __init__(self, wires: Union[int, List[int]] = 0, **kwargs) -> None:
+        """Initialise a SWAP gate.
+
+        Args:
+            wires: Qubit index or list of qubit indices this gate acts on.
+        """
+        super().__init__(wires=wires, **kwargs)
 
 
 class RandomUnitary(Operation):

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -317,8 +317,28 @@ class Operation:
         return op
 
     def __matmul__(self, other: "Operation") -> "Operation":
-        # TODO: implement tensor product of operations
-        pass
+        """Tensor (Kronecker) product of two operations.
+
+        The resulting operation acts on the union of both wire sets and
+        carries the Kronecker product of both matrices.  Wire sets must
+        be disjoint.
+
+        Returns:
+            A new :class:`Operation` whose matrix is ``self.matrix ⊗ other.matrix``
+            and whose wires are the concatenation of both wire lists.
+
+        Raises:
+            ValueError: If the two operations share any wires.
+        """
+        if set(self.wires) & set(other.wires):
+            raise ValueError(
+                f"Cannot take tensor product: overlapping wires "
+                f"{self.wires} and {other.wires}"
+            )
+        new_matrix = jnp.kron(self.matrix, other.matrix)
+        new_wires = self.wires + other.wires
+        op = Operation(wires=new_wires, matrix=new_matrix, record=False)
+        return op
 
     def lifted_matrix(self, n_qubits: int) -> jnp.ndarray:
         """Return the full ``2**n x 2**n`` matrix embedding this gate.

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -295,13 +295,13 @@ class Operation:
         return op
 
     def __mul__(self, factor: float) -> "Operation":
-        """Return a new operation, the product between x a scalar and U (``x*U``)
+        """Return a new operation, the product between U and a scalar (``U*x``)
         Usage inside a circuit function::
 
-            x * PauliX(wires=0)
+            PauliX(wires=0) * x
 
         Returns:
-            A new :class:`Operation` with matrix ``x*U`` acting on the same wires.
+            A new :class:`Operation` with matrix ``U*x`` acting on the same wires.
         """
         mat = factor * self._matrix
         op = Operation(wires=self.wires, matrix=mat, record=False)

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -535,17 +535,28 @@ class ParametrizedHamiltonian:
 
 
 class Id(Operation):
-    """Identity gate."""
+    """Identity gate.
+
+    Supports an arbitrary number of wires.  When more than one wire is
+    given the matrix is the ``2**k x 2**k`` identity (where *k* is the
+    number of wires).
+    """
 
     _matrix = jnp.eye(2, dtype=_cdtype())
-    _num_wires = 1
+    _num_wires = None  # accept any number of wires
 
     def __init__(self, wires: Union[int, List[int]] = 0, **kwargs) -> None:
         """Initialise an identity gate.
 
         Args:
             wires: Qubit index or list of qubit indices this gate acts on.
+                When multiple wires are given the matrix is automatically
+                expanded to the matching ``2**k × 2**k`` identity.
         """
+        w = list(wires) if isinstance(wires, (list, tuple)) else [wires]
+        k = len(w)
+        if k > 1:
+            kwargs["matrix"] = jnp.eye(2**k, dtype=_cdtype())
         super().__init__(wires=wires, **kwargs)
 
 
@@ -627,10 +638,13 @@ class S(Operation):
         """
         super().__init__(wires=wires)
 
+
 class SWAP(Operation):
     """SWAP gate."""
 
-    _matrix = jnp.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=_cdtype())
+    _matrix = jnp.array(
+        [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=_cdtype()
+    )
     _num_wires = 2
 
     def __init__(self, wires: Union[int, List[int]] = 0, **kwargs) -> None:

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -294,6 +294,25 @@ class Operation:
 
         return op
 
+    def __mul__(self, factor: float) -> "Operation":
+        """Return a new operation, the product between x a scalar and U (``x*U``)
+        Usage inside a circuit function::
+
+            x * PauliX(wires=0)
+
+        Returns:
+            A new :class:`Operation` with matrix ``x*U`` acting on the same wires.
+        """
+        mat = factor * self._matrix
+        op = Operation(wires=self.wires, matrix=mat, record=False)
+
+        self._update_tape_operation(op)
+
+        return op
+
+    # Also overwrite * for right operands
+    __rmul__ = __mul__
+
     def __add__(self, other: "Operation") -> "Operation":
         """Element-wise addition of two operations on the same wires.
 

--- a/qml_essentials/tape.py
+++ b/qml_essentials/tape.py
@@ -87,3 +87,26 @@ def pulse_recording() -> Iterator[list]:
         yield tape
     finally:
         stack.pop()
+
+
+def shift_and_append(tape_ops: List["Operation"], offset: int) -> None:
+    """Re-register *tape_ops* on the active tape with wires shifted by *offset*.
+
+    Each operation is shallow-copied so that the original tape is not
+    mutated.  This is useful for constructing multi-register circuits
+    where the same sub-circuit must be placed on different qubit
+    registers.
+
+    Args:
+        tape_ops: List of :class:`Operation` instances (typically captured
+            via :func:`recording`).
+        offset: Integer added to every wire index of every operation.
+    """
+    current = active_tape()
+    if current is None:
+        return
+    for o in tape_ops:
+        shifted = o.__class__.__new__(o.__class__)
+        shifted.__dict__.update(o.__dict__)
+        shifted._wires = [w + offset for w in o.wires]
+        current.append(shifted)

--- a/qml_essentials/tape.py
+++ b/qml_essentials/tape.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import threading
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional
 
 if TYPE_CHECKING:
     from qml_essentials.operations import Operation
@@ -90,7 +90,7 @@ def pulse_recording() -> Iterator[list]:
 
 
 def shift_and_append(tape_ops: List["Operation"], offset: int) -> None:
-    """Re-register *tape_ops* on the active tape with wires shifted by *offset*.
+    """Re-register tape_ops on the active tape with wires shifted by offset.
 
     Each operation is shallow-copied so that the original tape is not
     mutated.  This is useful for constructing multi-register circuits
@@ -110,3 +110,29 @@ def shift_and_append(tape_ops: List["Operation"], offset: int) -> None:
         shifted.__dict__.update(o.__dict__)
         shifted._wires = [w + offset for w in o.wires]
         current.append(shifted)
+
+
+def copy_to_tape(fn: Callable, offset: int) -> None:
+    """Record *fn* into a side tape and replay it shifted onto the active tape.
+
+    This is a convenience wrapper around :func:`recording` and
+    :func:`shift_and_append`.  It captures every operation emitted by
+    *fn* on a temporary tape, then appends shifted copies (wires
+    incremented by *offset*) to the currently active tape.
+
+    Typical usage inside a circuit function::
+
+        def my_circuit(params, inputs, ...):
+            # first copy on wires 0..n-1 (recorded directly)
+            model._variational(params, inputs, ...)
+            # second copy shifted to wires n..2n-1
+            copy_to_tape(lambda: model._variational(params, inputs, ...), offset=n)
+
+    Args:
+        fn: Zero-argument callable whose body instantiates ``Operation``
+            objects (they will be captured on the side tape).
+        offset: Integer added to every wire index before replaying.
+    """
+    with recording() as side_tape:
+        fn()
+    shift_and_append(side_tape, offset)

--- a/tests/test_entanglement.py
+++ b/tests/test_entanglement.py
@@ -196,6 +196,7 @@ def test_no_sampling() -> None:
     _ = Entanglement.relative_entropy(model, n_samples=None, n_sigmas=10)
     _ = Entanglement.entanglement_of_formation(model, n_samples=None)
     _ = Entanglement.concentratable_entanglement(model, n_samples=None)
+    _ = Entanglement.concentratable_entanglement_estimation(model, n_samples=None)
 
 
 @pytest.mark.unittest
@@ -326,56 +327,6 @@ def test_scaling() -> None:
 
 
 @pytest.mark.smoketest
-def test_relative_entropy() -> None:
-    separable_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Circuit_1",
-    )
-
-    entangled_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Strongly_Entangling",
-    )
-
-    ghz_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="GHZ",
-        data_reupload=False,
-    )
-
-    separable_ent = Entanglement.relative_entropy(
-        separable_model,
-        n_samples=10,
-        n_sigmas=20,
-        random_key=jax.random.key(1000),
-        scale=False,
-    )
-    entangled_ent = Entanglement.relative_entropy(
-        entangled_model,
-        n_samples=10,
-        n_sigmas=20,
-        random_key=jax.random.key(1000),
-        scale=False,
-    )
-    ghz_ent = Entanglement.relative_entropy(
-        ghz_model,
-        n_samples=10,
-        n_sigmas=20,
-        random_key=jax.random.key(1000),
-        scale=False,
-    )
-
-    assert 0.0 < separable_ent < entangled_ent < ghz_ent == 1.0, (
-        f"Order of entanglement should be 0 < Circuit_1 < Strongly Entangling < "
-        f"GHZ = 1, but got values 0 < {separable_ent} < {entangled_ent} < {ghz_ent} "
-        f"< 1"
-    )
-
-
-@pytest.mark.smoketest
 def test_relative_entropy_order() -> None:
 
     circuits = [
@@ -425,39 +376,6 @@ def test_relative_entropy_order() -> None:
 
 
 @pytest.mark.smoketest
-def test_entanglement_of_formation() -> None:
-    separable_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Circuit_1",
-    )
-
-    entangled_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Strongly_Entangling",
-    )
-
-    separable_ent = Entanglement.entanglement_of_formation(
-        separable_model,
-        n_samples=500,
-        random_key=jax.random.key(1000),
-        noise_params={"Depolarizing": 0.01},
-    )
-    entangled_ent = Entanglement.entanglement_of_formation(
-        entangled_model,
-        n_samples=500,
-        random_key=jax.random.key(1000),
-        noise_params={"Depolarizing": 0.01},
-    )
-
-    assert 0.0 <= separable_ent < entangled_ent <= 1.0, (
-        f"Order of entanglement should be 0 < Circuit_1 < Strongly Entangling < "
-        f"GHZ = 1, but got values 0 < {separable_ent} < {entangled_ent} < 1"
-    )
-
-
-@pytest.mark.smoketest
 def test_entanglement_of_formation_order() -> None:
 
     circuits = [
@@ -486,37 +404,6 @@ def test_entanglement_of_formation_order() -> None:
 
 
 @pytest.mark.smoketest
-def test_concentratable_entanglement() -> None:
-    separable_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Circuit_1",
-    )
-
-    entangled_model = Model(
-        n_qubits=3,
-        n_layers=1,
-        circuit_type="Strongly_Entangling",
-    )
-
-    separable_ent = Entanglement.concentratable_entanglement(
-        separable_model,
-        n_samples=100,
-        random_key=jax.random.key(1000),
-    )
-    entangled_ent = Entanglement.concentratable_entanglement(
-        entangled_model,
-        n_samples=100,
-        random_key=jax.random.key(1000),
-    )
-
-    assert 0.0 <= separable_ent < entangled_ent <= 1.0, (
-        f"Order of entanglement should be 0 < Circuit_1 < Strongly Entangling < "
-        f"GHZ = 1, but got values 0 < {separable_ent} < {entangled_ent} < 1"
-    )
-
-
-@pytest.mark.smoketest
 def test_concentratable_entanglement_order() -> None:
 
     circuits = [
@@ -532,6 +419,34 @@ def test_concentratable_entanglement_order() -> None:
         model = Model(n_qubits=3, n_layers=1, circuit_type=circuit)
 
         ent = Entanglement.concentratable_entanglement(
+            model,
+            n_samples=500,
+            random_key=jax.random.key(1000),
+        )
+        entanglement.append(ent)
+
+    assert all(
+        entanglement[i] <= entanglement[i + 1] for i in range(len(entanglement) - 1)
+    ), f"Order of entanglement should be\
+        {[(c, ent) for c, ent in zip(circuits, entanglement, strict=True)]}."
+
+
+@pytest.mark.smoketest
+def test_concentratable_entanglement_estimation_order() -> None:
+
+    circuits = [
+        "Circuit_1",
+        "Circuit_16",
+        "Circuit_19",
+        "Circuit_15",
+        "Strongly_Entangling",
+    ]
+
+    entanglement = []
+    for circuit in circuits:
+        model = Model(n_qubits=3, n_layers=1, circuit_type=circuit)
+
+        ent = Entanglement.concentratable_entanglement_estimation(
             model,
             n_samples=500,
             random_key=jax.random.key(1000),

--- a/tests/test_yaqsi.py
+++ b/tests/test_yaqsi.py
@@ -15,6 +15,7 @@ from qml_essentials.yaqsi import (
     build_parity_observable,
 )
 from qml_essentials.operations import (
+    Operation,
     H,
     CX,
     CCX,
@@ -28,7 +29,9 @@ from qml_essentials.operations import (
     RY,
     RZ,
     PauliX,
+    PauliY,
     PauliZ,
+    Id,
     Hermitian,
     ParametrizedHamiltonian,
     # noise channels
@@ -1237,6 +1240,143 @@ class TestGateOperations:
         script = Script(circuit)
         res = script.execute(type="expval", obs=obs)
         assert jnp.allclose(res, 1), "Dagger should undo operation"
+
+    @pytest.mark.unittest
+    def test_mul_scalar_right(self):
+        """PauliX * 2 should produce a matrix equal to 2 * X."""
+        x = PauliX(wires=0, record=False)
+        result = x * 2.0
+        expected = 2.0 * PauliX._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0]
+
+    @pytest.mark.unittest
+    def test_mul_scalar_left(self):
+        """2 * PauliX should produce a matrix equal to 2 * X (rmul)."""
+        x = PauliX(wires=0, record=False)
+        result = 2.0 * x
+        expected = 2.0 * PauliX._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0]
+
+    @pytest.mark.unittest
+    def test_mul_updates_tape(self):
+        """Scalar multiplication inside a circuit replaces the op on the tape."""
+        from qml_essentials.tape import recording
+
+        with recording() as tape:
+            PauliX(wires=0) * 0.5
+
+        assert len(tape) == 1, f"Expected 1 op on tape, got {len(tape)}"
+        expected = 0.5 * PauliX._matrix
+        assert jnp.allclose(tape[0].matrix, expected, atol=1e-10)
+
+    @pytest.mark.unittest
+    def test_mul_in_circuit(self):
+        """Scaled gate inside a circuit produces the expected expectation value.
+
+        0.5 * X has eigenvalues ±0.5, so ⟨0| (0.5·X) |0⟩ should still be 0.
+        """
+
+        def circuit():
+            PauliX(wires=0) * 0.5
+
+        script = Script(circuit)
+        # Use the scaled operator as observable
+        obs = [Operation(wires=0, matrix=0.5 * PauliX._matrix, record=False)]
+        res = script.execute(type="expval", obs=obs)
+        assert jnp.allclose(res, jnp.array([0.0]), atol=1e-10)
+
+    @pytest.mark.unittest
+    def test_add_same_wires(self):
+        """X + Z on the same wire should produce element-wise sum."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=0, record=False)
+        result = x + z
+        expected = PauliX._matrix + PauliZ._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0]
+
+    @pytest.mark.unittest
+    def test_add_preserves_hermiticity(self):
+        """Sum of two Hermitian operators is Hermitian: (X+Z)\\dagger = X+Z."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=0, record=False)
+        result = x + z
+        assert jnp.allclose(
+            result.matrix, jnp.conj(result.matrix).T, atol=1e-10
+        ), "Sum of Hermitian operators should be Hermitian"
+
+    @pytest.mark.unittest
+    def test_add_different_wires_raises(self):
+        """Adding operations on different wires must raise ValueError."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=1, record=False)
+        with pytest.raises(ValueError, match="same set of wires"):
+            _ = x + z
+
+    @pytest.mark.unittest
+    def test_add_self(self):
+        """X + X = 2 * X."""
+        x = PauliX(wires=0, record=False)
+        result = x + x
+        expected = 2.0 * PauliX._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+
+    @pytest.mark.unittest
+    def test_add_commutative(self):
+        """Addition should be commutative: X + Y == Y + X."""
+        x = PauliX(wires=0, record=False)
+        y = PauliY(wires=0, record=False)
+        assert jnp.allclose((x + y).matrix, (y + x).matrix, atol=1e-10)
+
+    @pytest.mark.unittest
+    def test_matmul_disjoint_wires(self):
+        """X(0) \\otimes Z(1) produces a 4x4 Kronecker product on wires [0, 1]."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=1, record=False)
+        result = x @ z
+        expected = jnp.kron(PauliX._matrix, PauliZ._matrix)
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1]
+
+    @pytest.mark.unittest
+    def test_matmul_overlapping_wires_raises(self):
+        """Tensor product with overlapping wires must raise ValueError."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=0, record=False)
+        with pytest.raises(ValueError, match="overlapping wires"):
+            _ = x @ z
+
+    @pytest.mark.unittest
+    def test_matmul_identity(self):
+        """X(0) \\otimes I(1) should equal X \\otimes I."""
+        x = PauliX(wires=0, record=False)
+        i = Id(wires=1, record=False)
+        result = x @ i
+        expected = jnp.kron(PauliX._matrix, Id._matrix)
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1]
+
+    @pytest.mark.unittest
+    def test_matmul_dimension(self):
+        """Tensor product of two 2x2 gates yields a 4x4 matrix."""
+        x = PauliX(wires=0, record=False)
+        y = PauliY(wires=1, record=False)
+        result = x @ y
+        assert result.matrix.shape == (4, 4)
+
+    @pytest.mark.unittest
+    def test_matmul_three_qubits(self):
+        """X(0) \\otimes Y(1) \\otimes Z(2) yields an 8x8 matrix on wires [0, 1, 2]."""
+        x = PauliX(wires=0, record=False)
+        y = PauliY(wires=1, record=False)
+        z = PauliZ(wires=2, record=False)
+        result = (x @ y) @ z
+        expected = jnp.kron(jnp.kron(PauliX._matrix, PauliY._matrix), PauliZ._matrix)
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1, 2]
+        assert result.matrix.shape == (8, 8)
 
 
 class TestMemory:


### PR DESCRIPTION
Beckey et al. show in ["Multipartite entanglement measures via Bell-basis measurements"](https://link.aps.org/doi/10.1103/PhysRevA.107.062425) how the concentratable enntanglements can be estimated using Bell basis measurements. The current method which relies on the panellized SWAP test, is quite slow. This should improve the performance drastically. I already got this to work using Pennylane, however I haven't yet manage to do so using Yaqsi. 