### PR TITLE
Complex numbers in FCC pearson and spearman correlation methods

### DIFF
--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -63,10 +63,7 @@ class Coefficients:
         kwargs.setdefault("force_mean", True)
         kwargs.setdefault("execution_type", "expval")
 
-
-        coeffs, freqs = cls._fourier_transform(
-            model, mfs=mfs, mts=mts, **kwargs
-        )
+        coeffs, freqs = cls._fourier_transform(model, mfs=mfs, mts=mts, **kwargs)
 
         if not jnp.isclose(jnp.sum(coeffs).imag, 0.0, rtol=1.0e-5):
             raise ValueError(
@@ -97,10 +94,8 @@ class Coefficients:
 
         return coeffs, freqs
 
-
     @classmethod
     def _fourier_transform(
-
         cls, model: Model, mfs: int, mts: int, **kwargs: Any
     ) -> jnp.ndarray:
         # Create a frequency vector with as many frequencies as model degrees,
@@ -143,8 +138,6 @@ class Coefficients:
             freqs,
         )
 
-
-
     @classmethod
     def get_psd(cls, coeffs: jnp.ndarray) -> jnp.ndarray:
         """
@@ -164,10 +157,9 @@ class Coefficients:
         scale = 2.0 / (len(coeffs) ** 2)
         return scale * abs2(coeffs)
 
-
-
     @classmethod
-    def evaluate_Fourier_series(cls,
+    def evaluate_Fourier_series(
+        cls,
         coefficients: jnp.ndarray,
         frequencies: jnp.ndarray,
         inputs: Union[jnp.ndarray, list, float],
@@ -1064,7 +1056,6 @@ class FCC:
             **kwargs,
         )
 
-
         return cls.calculate_fcc(fourier_fingerprint)
 
     @classmethod
@@ -1136,7 +1127,6 @@ class FCC:
 
         return fourier_fingerprint, freqs
 
-
     @classmethod
     def calculate_fcc(
         cls,
@@ -1193,7 +1183,6 @@ class FCC:
 
         return corr_mask
 
-
     @classmethod
     def _calculate_coefficients(
         cls,
@@ -1238,8 +1227,6 @@ class FCC:
 
         return model.params, coeffs, freqs
 
-
-
     @classmethod
     def _correlate(cls, mat: jnp.ndarray, method: str = "pearson") -> jnp.ndarray:
         """
@@ -1268,11 +1255,9 @@ class FCC:
         # will be in the bottom right quadrant
         if method == "pearson":
 
-
             result = cls._pearson(mat.reshape(mat.shape[0], -1))
             # result = cls._pearson(mat.reshape(mat.shape[-1], -1, order="F"))
         elif method == "spearman":
-
 
             result = cls._spearman(mat.reshape(mat.shape[0], -1))
             # result = cls._spearman(mat.reshape(mat.shape[-1], -1, order="F"))
@@ -1284,10 +1269,8 @@ class FCC:
 
         return result
 
-
     @classmethod
     def _pearson(
-
         cls, mat: jnp.ndarray, cov: Optional[bool] = False, minp: Optional[int] = 1
     ) -> jnp.ndarray:
         """
@@ -1320,7 +1303,6 @@ class FCC:
             mat = jnp.concatenate([mat.real, mat.imag], axis=0)
 
         mat = jnp.asarray(mat)
-        N, K = mat.shape
 
         # pre-compute finite mask  (N, K)
         mask = jnp.isfinite(mat)
@@ -1339,8 +1321,8 @@ class FCC:
         # Using: safe[:,i] * mask[:,j] zeroes out rows invalid for j.
         # Then summing over N gives sum_x[i,j].
         # safe.T @ fmask  gives (K, K) where entry (i,j) = sum of safe[:,i]*mask[:,j]
-        sum_x = safe.T @ fmask   # (K, K) – row-var sums
-        sum_y = fmask.T @ safe   # (K, K) – col-var sums
+        sum_x = safe.T @ fmask  # (K, K) – row-var sums
+        sum_y = fmask.T @ safe  # (K, K) – col-var sums
 
         # Note: explicit means (sum_x/nobs, sum_y/nobs) are not needed as
         # separate variables — the computational formula used below
@@ -1351,17 +1333,17 @@ class FCC:
         #   sxy = Σxy − (Σx)(Σy)/n
         # All sums are taken over the pairwise-valid subset for each (i,j).
         masked = safe * fmask  # same as safe but explicit
-        sum_xy = masked.T @ masked          # (K, K)
+        sum_xy = masked.T @ masked  # (K, K)
 
         # ssx[i,j] = sum_xx_ij - nobs * mean_x^2   (but sum_xx_ij uses pair mask)
         # We need sum of x^2 over the *pair* mask, not just column mask.
         # sum_x2[i,j] = sum_n  safe[n,i]^2 * mask[n,i] * mask[n,j]
-        safe_sq = safe ** 2
+        safe_sq = safe**2
         sum_x2 = safe_sq.T @ fmask  # (K, K)
         sum_y2 = fmask.T @ safe_sq  # (K, K)
 
-        ssx = sum_x2 - sum_x ** 2 / jnp.where(nobs > 0, nobs, 1.0)
-        ssy = sum_y2 - sum_y ** 2 / jnp.where(nobs > 0, nobs, 1.0)
+        ssx = sum_x2 - sum_x**2 / jnp.where(nobs > 0, nobs, 1.0)
+        ssy = sum_y2 - sum_y**2 / jnp.where(nobs > 0, nobs, 1.0)
         sxy = sum_xy - (sum_x * sum_y) / jnp.where(nobs > 0, nobs, 1.0)
 
         if cov:
@@ -1435,20 +1417,20 @@ class FCC:
         nobs = fmask.T @ fmask
 
         # Pairwise sums over mutually-valid rows
-        sum_x = safe_ranks.T @ fmask           # (K, K)
-        sum_y = fmask.T @ safe_ranks            # (K, K)
+        sum_x = safe_ranks.T @ fmask  # (K, K)
+        sum_y = fmask.T @ safe_ranks  # (K, K)
 
         # Pairwise products
-        masked_ranks = safe_ranks * fmask       # same as safe_ranks
+        masked_ranks = safe_ranks * fmask  # same as safe_ranks
         sum_xy = masked_ranks.T @ masked_ranks  # (K, K)
 
-        safe_sq = safe_ranks ** 2
-        sum_x2 = safe_sq.T @ fmask              # (K, K)
-        sum_y2 = fmask.T @ safe_sq              # (K, K)
+        safe_sq = safe_ranks**2
+        sum_x2 = safe_sq.T @ fmask  # (K, K)
+        sum_y2 = fmask.T @ safe_sq  # (K, K)
 
         nobs_safe = jnp.where(nobs > 0, nobs, 1.0)
-        ssx = sum_x2 - sum_x ** 2 / nobs_safe
-        ssy = sum_y2 - sum_y ** 2 / nobs_safe
+        ssx = sum_x2 - sum_x**2 / nobs_safe
+        ssy = sum_y2 - sum_y**2 / nobs_safe
         sxy = sum_xy - (sum_x * sum_y) / nobs_safe
 
         denom = jnp.sqrt(ssx * ssy)
@@ -1459,8 +1441,6 @@ class FCC:
         result = jnp.where(nobs < minp, jnp.nan, result)
 
         return result
-
-
 
     @classmethod
     def _weighting(cls, fourier_fingerprint: jnp.ndarray) -> jnp.ndarray:
@@ -1518,9 +1498,9 @@ class FCC:
 
 class Datasets:
 
-
     @classmethod
-    def generate_fourier_series(cls,
+    def generate_fourier_series(
+        cls,
         random_key: random.PRNGKey,
         model: Model,
         coefficients_min: float = 0.0,
@@ -1625,10 +1605,9 @@ class Datasets:
             coefficients.reshape(model.degree),
         ]
 
-
-
     @classmethod
-    def uniform_circle(cls,
+    def uniform_circle(
+        cls,
         random_key: random.PRNGKey,
         size: Union[jnp.ndarray, List, int],
         low=0.0,

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -1269,9 +1269,16 @@ class FCC:
         Compute Pearson correlation between columns of `mat`,
         permitting missing values (NaN or ±Inf).
 
+        If the input is complex, real and imaginary parts are stacked along
+        the sample axis so that both components contribute to the correlation
+        without discarding information.
+
         Args:
             mat : array_like, shape (N, K)
                 Input data.
+            cov : bool, optional
+                If True, return the sample covariance matrix instead of
+                correlation. Defaults to False.
             minp : int, optional
                 Minimum number of paired observations required to form a correlation.
                 If the number of valid pairs for (i, j) is < minp, the result is NaN.
@@ -1280,60 +1287,69 @@ class FCC:
             corr : ndarray, shape (K, K)
                 Pearson correlation matrix.
         """
+        # Preserve complex information by splitting into real / imag samples
+        if jnp.iscomplexobj(mat):
+            mat = jnp.concatenate([mat.real, mat.imag], axis=0)
 
-        mat = jnp.asarray(mat, dtype=jnp.float64)
+        mat = jnp.asarray(mat)
         N, K = mat.shape
 
-        # pre‐compute finite‐mask
+        # pre-compute finite mask  (N, K)
         mask = jnp.isfinite(mat)
+        fmask = mask.astype(mat.dtype)
 
-        # output
-        result = np.empty((K, K), dtype=jnp.float64)
+        # Replace non-finite entries with 0 so arithmetic is safe;
+        # the mask keeps track of validity.
+        safe = jnp.where(mask, mat, 0.0)
 
-        # TODO: optimize in future iterations
-        # loop over column‐pairs
-        for i in range(K):
-            for j in range(i + 1):
-                # find rows where both columns are finite
-                m = mask[:, i] & mask[:, j]
-                n = jnp.count_nonzero(m)
-                if n < minp:
-                    # too few pairs
-                    value = jnp.nan
-                else:
-                    x = mat[m, i]
-                    y = mat[m, j]
+        # Pairwise valid-observation counts  (K, K)
+        nobs = fmask.T @ fmask
 
-                    # compute means
-                    mean_x = x.mean()
-                    mean_y = y.mean()
+        # Pairwise sums (only over mutually valid rows)
+        # For columns i, j the "valid" rows are mask[:,i] & mask[:,j].
+        # sum_x[i,j] = sum of mat[:,i] where both i and j are valid.
+        # Using: safe[:,i] * mask[:,j] zeroes out rows invalid for j.
+        # Then summing over N gives sum_x[i,j].
+        # safe.T @ fmask  gives (K, K) where entry (i,j) = sum of safe[:,i]*mask[:,j]
+        sum_x = safe.T @ fmask   # (K, K) – row-var sums
+        sum_y = fmask.T @ safe   # (K, K) – col-var sums
 
-                    # demeaned data
-                    dx = x - mean_x
-                    dy = y - mean_y
+        # Means per pair
+        mean_x = jnp.where(nobs > 0, sum_x / nobs, 0.0)  # (K, K)
+        mean_y = jnp.where(nobs > 0, sum_y / nobs, 0.0)  # (K, K)
 
-                    # sum of squares and cross‐prod
-                    ssx = jnp.dot(dx, dx)
-                    ssy = jnp.dot(dy, dy)
-                    cxy = jnp.dot(dx, dy)
+        # Cross products, sum-of-squares
+        # For each pair (i, j) we need:
+        #   ssx = sum (x - mean_x)^2,  ssy = sum (y - mean_y)^2,
+        #   sxy = sum (x - mean_x)(y - mean_y)
+        # Expanding:  sxy = sum(x*y) - n*mean_x*mean_y
+        # with masked entries:
+        #   sum_xy[i,j] = sum_n safe[n,i]*safe[n,j] * mask[n,i]*mask[n,j]
+        masked = safe * fmask  # same as safe but explicit
+        sum_xy = masked.T @ masked          # (K, K)
 
-                    if cov:
-                        # sample covariance (denominator n−1)
-                        value = cxy / (n - 1) if n > 1 else jnp.nan
-                    else:
-                        # Pearson r = cov / (σx σy)
-                        denom = jnp.sqrt(ssx * ssy)
-                        if denom == 0.0:
-                            value = jnp.nan
-                        else:
-                            value = cxy / denom
-                            # clip numerical drift
-                            if value > 1.0:
-                                value = 1.0
-                            elif value < -1.0:
-                                value = -1.0
+        # ssx[i,j] = sum_xx_ij - nobs * mean_x^2   (but sum_xx_ij uses pair mask)
+        # We need sum of x^2 over the *pair* mask, not just column mask.
+        # sum_x2[i,j] = sum_n  safe[n,i]^2 * mask[n,i] * mask[n,j]
+        safe_sq = safe ** 2
+        sum_x2 = safe_sq.T @ fmask  # (K, K)
+        sum_y2 = fmask.T @ safe_sq  # (K, K)
 
-                result[i, j] = result[j, i] = value
+        ssx = sum_x2 - sum_x ** 2 / jnp.where(nobs > 0, nobs, 1.0)
+        ssy = sum_y2 - sum_y ** 2 / jnp.where(nobs > 0, nobs, 1.0)
+        sxy = sum_xy - (sum_x * sum_y) / jnp.where(nobs > 0, nobs, 1.0)
+
+        if cov:
+            denom = jnp.where(nobs > 1, nobs - 1, jnp.nan)
+            result = sxy / denom
+        else:
+            denom = jnp.sqrt(ssx * ssy)
+            result = jnp.where(denom > 0, sxy / denom, jnp.nan)
+            # clip numerical drift to [-1, 1]
+            result = jnp.clip(result, -1.0, 1.0)
+
+        # Enforce minp: set entries with too few observations to NaN
+        result = jnp.where(nobs < minp, jnp.nan, result)
 
         return result
 
@@ -1344,6 +1360,10 @@ class FCC:
 
         Compute Spearman correlation between columns of `mat`,
         permitting missing values (NaN or ±Inf).
+
+        If the input is complex, real and imaginary parts are stacked along
+        the sample axis so that both components contribute to the correlation
+        without discarding information.
 
         Args:
             mat : array_like, shape (N, K)
@@ -1356,47 +1376,61 @@ class FCC:
             corr : ndarray, shape (K, K)
                 Spearman correlation matrix.
         """
+        # Preserve complex information by splitting into real / imag samples
+        if jnp.iscomplexobj(mat):
+            mat = jnp.concatenate([mat.real, mat.imag], axis=0)
+
+        mat = jnp.asarray(mat)
         N, K = mat.shape
+
         # trivial all-NaN answer if too few rows
         if N < minp:
-            return jnp.full((K, K), jnp.nan, dtype=float)
+            return jnp.full((K, K), jnp.nan)
 
         # mask of finite entries
         mask = jnp.isfinite(mat)  # shape (N, K), dtype=bool
 
         # precompute ranks column-wise ignoring NaNs
-        ranks = np.full((N, K), jnp.nan, dtype=float)
+        ranks = np.full((N, K), np.nan)
         for j in range(K):
             valid = mask[:, j]
             if valid.any():
-                # rankdata by default gives average ranks for ties
                 ranks[valid, j] = rankdata(mat[valid, j], method="average")
 
-        # allocate result
-        result = np.empty((K, K), dtype=float)
+        ranks = jnp.asarray(ranks)
 
-        # TODO: optimize in future iterations
-        # loop lower triangle (including diagonal)
-        for i in range(K):
-            for j in range(i + 1):
-                # find rows where both columns are finite
-                valid = mask[:, i] & mask[:, j]
-                nobs = valid.sum()
+        # Vectorised Pearson on the ranks
+        # Replace NaN ranks with 0; use mask to track validity.
+        rank_mask = jnp.isfinite(ranks)
+        safe_ranks = jnp.where(rank_mask, ranks, 0.0)
 
-                if nobs < minp:
-                    rho = jnp.nan
-                else:
-                    xi = ranks[valid, i]
-                    yj = ranks[valid, j]
-                    # subtract means
-                    xi = xi - xi.mean()
-                    yj = yj - yj.mean()
-                    num = jnp.dot(xi, yj)
-                    den = jnp.sqrt(jnp.dot(xi, xi) * jnp.dot(yj, yj))
-                    rho = num / den if den > 0 else jnp.nan
+        # Pairwise valid-observation counts  (K, K)
+        fmask = rank_mask.astype(ranks.dtype)
+        nobs = fmask.T @ fmask
 
-                result[i, j] = rho
-                result[j, i] = rho
+        # Pairwise sums over mutually-valid rows
+        sum_x = safe_ranks.T @ fmask           # (K, K)
+        sum_y = fmask.T @ safe_ranks            # (K, K)
+
+        # Pairwise products
+        masked_ranks = safe_ranks * fmask       # same as safe_ranks
+        sum_xy = masked_ranks.T @ masked_ranks  # (K, K)
+
+        safe_sq = safe_ranks ** 2
+        sum_x2 = safe_sq.T @ fmask              # (K, K)
+        sum_y2 = fmask.T @ safe_sq              # (K, K)
+
+        nobs_safe = jnp.where(nobs > 0, nobs, 1.0)
+        ssx = sum_x2 - sum_x ** 2 / nobs_safe
+        ssy = sum_y2 - sum_y ** 2 / nobs_safe
+        sxy = sum_xy - (sum_x * sum_y) / nobs_safe
+
+        denom = jnp.sqrt(ssx * ssy)
+        result = jnp.where(denom > 0, sxy / denom, jnp.nan)
+        result = jnp.clip(result, -1.0, 1.0)
+
+        # Enforce minp
+        result = jnp.where(nobs < minp, jnp.nan, result)
 
         return result
 

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -1314,17 +1314,14 @@ class FCC:
         sum_x = safe.T @ fmask   # (K, K) – row-var sums
         sum_y = fmask.T @ safe   # (K, K) – col-var sums
 
-        # Means per pair
-        mean_x = jnp.where(nobs > 0, sum_x / nobs, 0.0)  # (K, K)
-        mean_y = jnp.where(nobs > 0, sum_y / nobs, 0.0)  # (K, K)
+        # Note: explicit means (sum_x/nobs, sum_y/nobs) are not needed as
+        # separate variables — the computational formula used below
+        # (e.g. ssx = Σx² − (Σx)²/n) implicitly handles mean-centering.
 
-        # Cross products, sum-of-squares
-        # For each pair (i, j) we need:
-        #   ssx = sum (x - mean_x)^2,  ssy = sum (y - mean_y)^2,
-        #   sxy = sum (x - mean_x)(y - mean_y)
-        # Expanding:  sxy = sum(x*y) - n*mean_x*mean_y
-        # with masked entries:
-        #   sum_xy[i,j] = sum_n safe[n,i]*safe[n,j] * mask[n,i]*mask[n,j]
+        # Cross products, sum-of-squares via computational formula:
+        #   ssx = Σx² − (Σx)²/n,  ssy = Σy² − (Σy)²/n,
+        #   sxy = Σxy − (Σx)(Σy)/n
+        # All sums are taken over the pairwise-valid subset for each (i,j).
         masked = safe * fmask  # same as safe but explicit
         sum_xy = masked.T @ masked          # (K, K)
 

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -487,13 +487,78 @@ class TestFCC:
                 )
 
     @pytest.mark.unittest
+    def test_pearson_correlation_complex(self) -> None:
+        """Pearson on complex input should match scipy on stacked real/imag."""
+        N = 1000
+        K = 5
+        seed = 42
+        rng = np.random.default_rng(seed)
+
+        coeffs = rng.normal(size=(N, K)) + 1j * rng.normal(size=(N, K))
+        pearson = FCC._pearson(jnp.array(coeffs))
+
+        # Reference: stack real and imag along sample axis, then use scipy
+        stacked = np.concatenate([coeffs.real, coeffs.imag], axis=0)
+        for i in range(K):
+            for j in range(K):
+                reference = pearsonr(stacked[:, i], stacked[:, j]).correlation
+                assert jnp.isclose(pearson[i, j], reference, atol=1.0e-5), (
+                    f"Complex Pearson mismatch at ({i},{j}): "
+                    f"got {pearson[i, j]}, expected {reference}"
+                )
+
+    @pytest.mark.unittest
+    def test_spearman_correlation_complex(self) -> None:
+        """Spearman on complex input should match scipy on stacked real/imag."""
+        N = 1000
+        K = 5
+        seed = 42
+        rng = np.random.default_rng(seed)
+
+        coeffs = rng.normal(size=(N, K)) + 1j * rng.normal(size=(N, K))
+        spearman = FCC._spearman(jnp.array(coeffs))
+
+        # Reference: stack real and imag along sample axis, then use scipy
+        stacked = np.concatenate([coeffs.real, coeffs.imag], axis=0)
+        for i in range(K):
+            for j in range(K):
+                reference = spearmanr(stacked[:, i], stacked[:, j]).correlation
+                assert jnp.isclose(spearman[i, j], reference, atol=1.0e-5), (
+                    f"Complex Spearman mismatch at ({i},{j}): "
+                    f"got {spearman[i, j]}, expected {reference}"
+                )
+
+    @pytest.mark.unittest
+    def test_pearson_complex_preserves_imaginary(self) -> None:
+        """Ensure complex correlations differ from real-only correlations,
+        i.e. the imaginary part is not silently discarded."""
+        N = 200
+        K = 4
+        seed = 123
+        rng = np.random.default_rng(seed)
+
+        real_part = rng.normal(size=(N, K))
+        imag_part = rng.normal(size=(N, K))
+        coeffs_complex = jnp.array(real_part + 1j * imag_part)
+        coeffs_real_only = jnp.array(real_part)
+
+        corr_complex = FCC._pearson(coeffs_complex)
+        corr_real = FCC._pearson(coeffs_real_only)
+
+        # They should generally differ (imaginary part contributes)
+        assert not jnp.allclose(corr_complex, corr_real, atol=1.0e-3), (
+            "Complex and real-only Pearson correlations should differ "
+            "when imaginary components carry information."
+        )
+
+    @pytest.mark.unittest
     @pytest.mark.parametrize(
         "circuit_type, expected_fcc",
         [
             ("Circuit_20", 0.004),
             ("Circuit_19", 0.010),
-            ("Circuit_17", 0.115),
-            ("Hardware_Efficient", 0.144),
+            ("Circuit_17", 0.078),
+            ("Hardware_Efficient", 0.080),
         ],
         ids=["Circuit_20", "Circuit_19", "Circuit_17", "Hardware_Efficient"],
     )
@@ -521,22 +586,9 @@ class TestFCC:
     @pytest.mark.parametrize(
         "encoding_strategy, circuit_type, n_qubits, n_layers, n_samples",
         [
-            ("hamming", "Circuit_1", 3, 1, 10),
-            ("hamming", "Circuit_3", 4, 1, 10),
-            ("binary", "Circuit_1", 3, 1, 10),
-            ("binary", "Circuit_3", 4, 1, 10),
-            ("binary", "Circuit_1", 4, 1, 5),
-            ("ternary", "Circuit_1", 3, 1, 10),
-            ("ternary", "Circuit_3", 3, 1, 10),
-        ],
-        ids=[
-            "hamming-C1-3q",
-            "hamming-C3-4q",
-            "binary-C1-3q",
-            "binary-C3-4q",
-            "binary-C1-4q",
-            "ternary-C1-3q",
-            "ternary-C3-3q",
+            ("hamming", "Circuit_2", 2, 2, 5),
+            ("binary", "Circuit_2", 2, 2, 5),
+            ("ternary", "Circuit_2", 2, 2, 5),
         ],
     )
     def test_fcc_encoding_strategies(

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -517,6 +517,87 @@ class TestFCC:
             fcc, expected_fcc, atol=3.0e-2
         ), f"Wrong FCC for {circuit_type}. Got {fcc}, expected {expected_fcc}."
 
+    @pytest.mark.unittest
+    @pytest.mark.parametrize(
+        "encoding_strategy, circuit_type, n_qubits, n_layers, n_samples",
+        [
+            ("hamming", "Circuit_1", 3, 1, 10),
+            ("hamming", "Circuit_3", 4, 1, 10),
+            ("binary", "Circuit_1", 3, 1, 10),
+            ("binary", "Circuit_3", 4, 1, 10),
+            ("binary", "Circuit_1", 4, 1, 5),
+            ("ternary", "Circuit_1", 3, 1, 10),
+            ("ternary", "Circuit_3", 3, 1, 10),
+        ],
+        ids=[
+            "hamming-C1-3q",
+            "hamming-C3-4q",
+            "binary-C1-3q",
+            "binary-C3-4q",
+            "binary-C1-4q",
+            "ternary-C1-3q",
+            "ternary-C3-3q",
+        ],
+    )
+    def test_fcc_encoding_strategies(
+        self, encoding_strategy, circuit_type, n_qubits, n_layers, n_samples
+    ) -> None:
+        """
+        Test that the FCC is bounded in [0, 1] for Hamming, Binary,
+        and Ternary encoding strategies.
+        """
+        enc = Encoding(encoding_strategy, "RX")
+        model = Model(
+            n_qubits=n_qubits,
+            n_layers=n_layers,
+            circuit_type=circuit_type,
+            encoding=enc,
+            output_qubit=-1,
+        )
+
+        # Verify spectrum computation succeeds
+        model.initialize_params(repeat=n_samples)
+        coeffs, freqs = Coefficients.get_spectrum(
+            model, shift=True, trim=True, force_mean=True, execution_type="expval"
+        )
+        assert coeffs.shape[0] == model.degree[0], (
+            f"Wrong number of coefficients for {encoding_strategy}: "
+            f"{coeffs.shape[0]}, expected {model.degree[0]}"
+        )
+
+        # Verify correlation values are bounded
+        fp_pearson = FCC._correlate(coeffs.transpose(), method="pearson")
+        assert np.all(np.abs(fp_pearson[np.isfinite(fp_pearson)]) <= 1.0 + 1e-10), (
+            f"Pearson correlation out of [-1, 1] for {encoding_strategy}. "
+            f"Max |r| = {np.max(np.abs(fp_pearson[np.isfinite(fp_pearson)]))}"
+        )
+
+        fp_spearman = FCC._correlate(coeffs.transpose(), method="spearman")
+        assert np.all(
+            np.abs(fp_spearman[np.isfinite(fp_spearman)]) <= 1.0 + 1e-10
+        ), (
+            f"Spearman correlation out of [-1, 1] for {encoding_strategy}. "
+            f"Max |rho| = {np.max(np.abs(fp_spearman[np.isfinite(fp_spearman)]))}"
+        )
+
+        # Verify FCC is bounded in [0, 1] with both methods
+        for method in ["pearson", "spearman"]:
+            fcc = FCC.get_fcc(
+                model, n_samples=n_samples, method=method, trim_redundant=True
+            )
+            assert 0.0 <= float(fcc) <= 1.0, (
+                f"FCC out of [0, 1] for {encoding_strategy}/{method}: {float(fcc)}"
+            )
+
+            # Also test without trimming
+            fcc_untrimmed = FCC.get_fcc(
+                model, n_samples=n_samples, method=method, trim_redundant=False
+            )
+            assert 0.0 <= float(fcc_untrimmed) <= 1.0, (
+                f"FCC (untrimmed) out of [0, 1] for "
+                f"{encoding_strategy}/{method}: {float(fcc_untrimmed)}"
+            )
+
     @pytest.mark.smoketest
     @pytest.mark.parametrize(
         "circuit_type",

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -698,7 +698,7 @@ class TestFCC:
             scale=True,
         )
         assert jnp.isclose(
-            fcc, 0.020, atol=2.0e-3
+            fcc, 0.016, atol=2.0e-3
         ), f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.020."
 
     @pytest.mark.unittest


### PR DESCRIPTION
In the previous implementation, complex values were silently truncated due to a `jnp.float` cast.
This is now fixed, by handling correlations for complex and real values separately.

As a result, I had to slightly modify the test values for checking the FCC calculation.