### PR TITLE
Generalized product operations

### DIFF
--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -243,9 +243,9 @@ class Block:
             self.gate = gate
 
         if self.is_entangling:
-            assert (
-                topology is not None
-            ), "Topology must be specified for entangling gates"
+            assert topology is not None, (
+                "Topology must be specified for entangling gates"
+            )
 
         self.topology = topology
         self.kwargs = kwargs
@@ -408,13 +408,11 @@ class Ansaetze:
         return ansaetze
 
     class No_Ansatz(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return ()
 
     class GHZ(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -435,7 +433,6 @@ class Ansaetze:
             return n_params
 
     class Circuit_1(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -444,7 +441,6 @@ class Ansaetze:
             )
 
     class Circuit_2(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -457,7 +453,6 @@ class Ansaetze:
             )
 
     class Circuit_3(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -467,7 +462,6 @@ class Ansaetze:
             )
 
     class Circuit_4(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -477,7 +471,6 @@ class Ansaetze:
             )
 
     class Circuit_5(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -489,7 +482,6 @@ class Ansaetze:
             )
 
     class Circuit_6(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -501,7 +493,6 @@ class Ansaetze:
             )
 
     class Circuit_7(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -521,7 +512,6 @@ class Ansaetze:
             )
 
     class Circuit_8(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -541,7 +531,6 @@ class Ansaetze:
             )
 
     class Circuit_9(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -551,7 +540,6 @@ class Ansaetze:
             )
 
     class Circuit_10(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -561,7 +549,6 @@ class Ansaetze:
             )
 
     class Circuit_13(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -586,7 +573,6 @@ class Ansaetze:
             )
 
     class Circuit_14(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -611,7 +597,6 @@ class Ansaetze:
             )
 
     class Circuit_15(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -636,7 +621,6 @@ class Ansaetze:
             )
 
     class Circuit_16(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -654,7 +638,6 @@ class Ansaetze:
             )
 
     class Circuit_17(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -672,7 +655,6 @@ class Ansaetze:
             )
 
     class Circuit_18(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -687,7 +669,6 @@ class Ansaetze:
             )
 
     class Circuit_19(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -702,7 +683,6 @@ class Ansaetze:
             )
 
     class Circuit_20(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -726,13 +706,11 @@ class Ansaetze:
             )
 
     class No_Entangling(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (Block(gate=Gates.Rot),)
 
     class Hardware_Efficient(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (
@@ -755,7 +733,6 @@ class Ansaetze:
             )
 
     class Strongly_Entangling(DeclarativeCircuit):
-
         @classmethod
         def structure(cls):
             return (

--- a/qml_essentials/ansaetze.py
+++ b/qml_essentials/ansaetze.py
@@ -165,8 +165,6 @@ class DeclarativeCircuit(Circuit):
     `get_control_indices`, and `build` are derived automatically.
     """
 
-
-
     @classmethod
     def structure(cls) -> Tuple[Any, ...]:
         """Override in subclass to return the structure tuple."""
@@ -411,13 +409,11 @@ class Ansaetze:
 
     class No_Ansatz(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return ()
 
     class GHZ(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -426,15 +422,11 @@ class Ansaetze:
                 Block(gate=Gates.CX, topology=Topology.stairs, reverse=True),
             )
 
-
-
         @classmethod
         def build(cls, w: np.ndarray, n_qubits: int, **kwargs):
             Gates.H(wires=0, **kwargs)
             for q in range(n_qubits - 1):
                 Gates.CX(wires=[q, q + 1], **kwargs)
-
-
 
         @classmethod
         def n_pulse_params_per_layer(cls, n_qubits: int) -> int:
@@ -444,7 +436,6 @@ class Ansaetze:
 
     class Circuit_1(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -453,7 +444,6 @@ class Ansaetze:
             )
 
     class Circuit_2(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -468,7 +458,6 @@ class Ansaetze:
 
     class Circuit_3(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -479,7 +468,6 @@ class Ansaetze:
 
     class Circuit_4(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -489,7 +477,6 @@ class Ansaetze:
             )
 
     class Circuit_5(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -503,7 +490,6 @@ class Ansaetze:
 
     class Circuit_6(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -515,7 +501,6 @@ class Ansaetze:
             )
 
     class Circuit_7(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -537,7 +522,6 @@ class Ansaetze:
 
     class Circuit_8(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -558,7 +542,6 @@ class Ansaetze:
 
     class Circuit_9(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -569,7 +552,6 @@ class Ansaetze:
 
     class Circuit_10(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -579,7 +561,6 @@ class Ansaetze:
             )
 
     class Circuit_13(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -606,7 +587,6 @@ class Ansaetze:
 
     class Circuit_14(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -631,7 +611,6 @@ class Ansaetze:
             )
 
     class Circuit_15(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -658,7 +637,6 @@ class Ansaetze:
 
     class Circuit_16(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -676,7 +654,6 @@ class Ansaetze:
             )
 
     class Circuit_17(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -696,7 +673,6 @@ class Ansaetze:
 
     class Circuit_18(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -712,7 +688,6 @@ class Ansaetze:
 
     class Circuit_19(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (
@@ -727,7 +702,6 @@ class Ansaetze:
             )
 
     class Circuit_20(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -753,13 +727,11 @@ class Ansaetze:
 
     class No_Entangling(DeclarativeCircuit):
 
-
         @classmethod
         def structure(cls):
             return (Block(gate=Gates.Rot),)
 
     class Hardware_Efficient(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):
@@ -783,7 +755,6 @@ class Ansaetze:
             )
 
     class Strongly_Entangling(DeclarativeCircuit):
-
 
         @classmethod
         def structure(cls):

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 
 
 class Coefficients:
-
     @classmethod
     def get_spectrum(
         cls,
@@ -249,9 +248,9 @@ class FourierTree:
             """
             self.parameter_idx = parameter_idx
 
-            assert not (
-                is_sine_factor and is_cosine_factor
-            ), "Cannot be sine and cosine at the same time"
+            assert not (is_sine_factor and is_cosine_factor), (
+                "Cannot be sine and cosine at the same time"
+            )
             self.is_sine_factor = is_sine_factor
             self.is_cosine_factor = is_cosine_factor
 
@@ -1002,7 +1001,6 @@ class FourierTree:
 
 
 class FCC:
-
     @classmethod
     def get_fcc(
         cls,
@@ -1254,11 +1252,9 @@ class FCC:
         # such that after correlation, all positive indexed coefficients
         # will be in the bottom right quadrant
         if method == "pearson":
-
             result = cls._pearson(mat.reshape(mat.shape[0], -1))
             # result = cls._pearson(mat.reshape(mat.shape[-1], -1, order="F"))
         elif method == "spearman":
-
             result = cls._spearman(mat.reshape(mat.shape[0], -1))
             # result = cls._spearman(mat.reshape(mat.shape[-1], -1, order="F"))
         else:
@@ -1457,11 +1453,13 @@ class FCC:
         assert (
             fourier_fingerprint.shape[0] % 2 != 0
             and fourier_fingerprint.shape[1] % 2 != 0
-        ), "Correlation matrix must have odd dimensions. \
+        ), (
+            "Correlation matrix must have odd dimensions. \
             Hint: use `trim` argument when calling `get_spectrum`."
-        assert (
-            fourier_fingerprint.shape[0] == fourier_fingerprint.shape[1]
-        ), "Correlation matrix must be square."
+        )
+        assert fourier_fingerprint.shape[0] == fourier_fingerprint.shape[1], (
+            "Correlation matrix must be square."
+        )
 
         def quadrant_to_matrix(a: jnp.ndarray) -> jnp.ndarray:
             """
@@ -1497,7 +1495,6 @@ class FCC:
 
 
 class Datasets:
-
     @classmethod
     def generate_fourier_series(
         cls,

--- a/qml_essentials/drawing.py
+++ b/qml_essentials/drawing.py
@@ -44,7 +44,7 @@ class TikzFigure:
 \\end{{figure}}"""
 
     def export(
-            self, destination: str, full_document: bool = False, mode: str = "w"
+        self, destination: str, full_document: bool = False, mode: str = "w"
     ) -> None:
         """
         Export a LaTeX document with a quantum circuit in stick notation.

--- a/qml_essentials/entanglement.py
+++ b/qml_essentials/entanglement.py
@@ -152,7 +152,7 @@ class Entanglement:
                     inputs,
                     pulse_params=pulse_params,
                     random_key=random_key,
-                    **kw
+                    **kw,
                 )
 
             # First copy on wires 0..n-1
@@ -293,9 +293,7 @@ class Entanglement:
         # Entropy of GHZ states should be maximal
         ghz_model = Model(model.n_qubits, 1, "GHZ", data_reupload=False)
         rho_ghz, log_rho_ghz = cls._compute_log_density(ghz_model, **kwargs)
-        ghz_entropies = cls._compute_rel_entropies(
-            rho_ghz, log_rho_ghz, log_sigmas
-        )
+        ghz_entropies = cls._compute_rel_entropies(rho_ghz, log_rho_ghz, log_sigmas)
 
         normalised_entropies = rel_entropies / ghz_entropies
 
@@ -517,7 +515,7 @@ class Entanglement:
                     inputs,
                     pulse_params=pulse_params,
                     random_key=random_key,
-                    **kw
+                    **kw,
                 )
 
             # First copy on wires n..2n-1
@@ -656,9 +654,10 @@ class Entanglement:
         # Construct observable for measuring CE
         CE_observable = op.Id([0, n]) + op.Operation([0, n], SWAP)
         for i in range(1, n):
-            CE_observable = (CE_observable @
-                             (op.Id([i, i + n]) + op.Operation([i, i + n], SWAP)))
-        CE_observable = (1/N) * CE_observable
+            CE_observable = CE_observable @ (
+                op.Id([i, i + n]) + op.Operation([i, i + n], SWAP)
+            )
+        CE_observable = (1 / N) * CE_observable
 
         expvals = []
         if n_batch > 1:

--- a/qml_essentials/expressibility.py
+++ b/qml_essentials/expressibility.py
@@ -147,9 +147,7 @@ class Expressibility:
         for idx in range(n_bins):
             v = idx / n_bins
             u = (idx + 1) / n_bins
-            dist[idx], _ = integrate.quad(
-                cls._haar_probability, v, u, args=(n_qubits,)
-            )
+            dist[idx], _ = integrate.quad(cls._haar_probability, v, u, args=(n_qubits,))
 
         return dist
 

--- a/qml_essentials/model.py
+++ b/qml_essentials/model.py
@@ -309,17 +309,17 @@ class Model:
             value: Qubit index or list of indices. Use -1 for all qubits.
         """
         if isinstance(value, list):
-            assert (
-                len(value) <= self.n_qubits
-            ), f"Size of output_qubit {len(value)} cannot be\
+            assert len(value) <= self.n_qubits, (
+                f"Size of output_qubit {len(value)} cannot be\
             larger than number of qubits {self.n_qubits}."
+            )
         elif isinstance(value, int):
             if value == -1:
                 value = list(range(self.n_qubits))
             else:
-                assert (
-                    value < self.n_qubits
-                ), f"Output qubit {value} cannot be larger than {self.n_qubits}."
+                assert value < self.n_qubits, (
+                    f"Output qubit {value} cannot be larger than {self.n_qubits}."
+                )
                 value = [value]
 
         self._output_qubit = value
@@ -462,10 +462,12 @@ class Model:
                 assert value.shape == (
                     self.n_layers,
                     self.n_qubits,
-                ), f"Data reuploading array has wrong shape. \
+                ), (
+                    f"Data reuploading array has wrong shape. \
                     Expected {(self.n_layers, self.n_qubits)} or\
                     {(self.n_layers, self.n_qubits, self.n_input_feat)},\
                     got {value.shape}."
+                )
                 value = value.reshape(*value.shape, 1)
                 value = np.repeat(value, self.n_input_feat, axis=2)
 
@@ -473,9 +475,11 @@ class Model:
                 self.n_layers,
                 self.n_qubits,
                 self.n_input_feat,
-            ), f"Data reuploading array has wrong shape. \
+            ), (
+                f"Data reuploading array has wrong shape. \
                 Expected {(self.n_layers, self.n_qubits, self.n_input_feat)},\
                 got {value.shape}."
+            )
 
             log.debug(f"Data reuploading array:\n{value}")
         else:

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -294,16 +294,22 @@ class Operation:
 
         return op
 
-    def __mul__(self, factor: float) -> "Operation":
+    def __mul__(self, other: Union[float, "Operation"]) -> "Operation":
         """Return a new operation, the product between U and a scalar (``U*x``)
+        or the composition of two operations.
         Usage inside a circuit function::
 
             PauliX(wires=0) * x
+            PauliX(wires=0) * PauliZ(wires=0)
 
         Returns:
-            A new :class:`Operation` with matrix ``U*x`` acting on the same wires.
+            A new :class:`Operation` with matrix ``U*x`` acting on the same wires,
+            or the composed matrix acting on the appropriate wires.
         """
-        mat = factor * self._matrix
+        if isinstance(other, Operation):
+            return self.__matmul__(other)
+
+        mat = other * self._matrix
         op = Operation(wires=self.wires, matrix=mat, record=False)
 
         self._update_tape_operation(op)
@@ -335,29 +341,60 @@ class Operation:
         )
         return op
 
-    def __matmul__(self, other: "Operation") -> "Operation":
-        """Tensor (Kronecker) product of two operations.
+    def prod(self, *ops: "Operation") -> "Operation":
+        """Construct the generalized product (tensor or matrix) of this operation with others.
 
-        The resulting operation acts on the union of both wire sets and
-        carries the Kronecker product of both matrices.  Wire sets must
-        be disjoint.
+        The resulting operation acts on the union of all wire sets.
+        If the wire sets are disjoint, this is a Kronecker product.
+        If the wire sets overlap, the corresponding matrices are multiplied.
+
+        Usage::
+
+            res = op1.prod(op2, op3)
+            # or
+            res = Operation.prod(op1, op2, op3)
+
+        Args:
+            *ops: Variable number of :class:`Operation` instances.
 
         Returns:
-            A new :class:`Operation` whose matrix is ``self.matrix ⊗ other.matrix``
-            and whose wires are the concatenation of both wire lists.
-
-        Raises:
-            ValueError: If the two operations share any wires.
+            A new :class:`Operation` representing the composed operation.
         """
-        if set(self.wires) & set(other.wires):
-            raise ValueError(
-                f"Cannot take tensor product: overlapping wires "
-                f"{self.wires} and {other.wires}"
-            )
-        new_matrix = jnp.kron(self.matrix, other.matrix)
-        new_wires = self.wires + other.wires
-        op = Operation(wires=new_wires, matrix=new_matrix, record=False)
-        return op
+        if not ops:
+            return self
+
+        all_ops = (self,) + ops
+        all_wires = []
+        for op in all_ops:
+            for w in op.wires:
+                if w not in all_wires:
+                    all_wires.append(w)
+
+        n = len(all_wires)
+
+        mat = _embed_matrix(all_ops[0].matrix, all_ops[0].wires, all_wires, n)
+        for op in all_ops[1:]:
+            mat_other = _embed_matrix(op.matrix, op.wires, all_wires, n)
+            mat = mat @ mat_other
+
+        op_names = "*".join(op.name for op in all_ops)
+        return Operation(wires=all_wires, matrix=mat, name=f"Prod({op_names})", record=False)
+
+    def __matmul__(self, other: "Operation") -> "Operation":
+        """Tensor (Kronecker) product or matrix product of two operations.
+
+        The resulting operation acts on the union of both wire sets.
+        If the wire sets are disjoint, this is a Kronecker product.
+        If the wire sets overlap, the corresponding matrices are multiplied.
+
+        Returns:
+            A new :class:`Operation` whose matrix represents the composed
+            operation on the unified wire set.
+        """
+        if not isinstance(other, Operation):
+            return NotImplemented
+
+        return self.prod(other)
 
     def lifted_matrix(self, n_qubits: int) -> jnp.ndarray:
         """Return the full ``2**n x 2**n`` matrix embedding this gate.
@@ -1703,3 +1740,22 @@ def pauli_string_from_operation(op: Operation) -> str:
     # Fall back: decompose the matrix
     _, pauli_op = pauli_decompose(op.matrix, wire_order=op.wires)
     return pauli_op._pauli_label
+
+
+def prod(*ops: Operation) -> Operation:
+    """Construct the generalized product (tensor or matrix) of multiple operations.
+
+    The resulting operation acts on the union of all wire sets.
+    If the wire sets are disjoint, this is a Kronecker product.
+    If the wire sets overlap, the corresponding matrices are multiplied.
+
+    Args:
+        *ops: Variable number of :class:`Operation` instances.
+
+    Returns:
+        A new :class:`Operation` whose matrix represents the composed
+        operation on the unified wire set.
+    """
+    if not ops:
+        raise ValueError("At least one operation must be provided to prod().")
+    return ops[0].prod(*ops[1:])

--- a/qml_essentials/operations.py
+++ b/qml_essentials/operations.py
@@ -342,7 +342,8 @@ class Operation:
         return op
 
     def prod(self, *ops: "Operation") -> "Operation":
-        """Construct the generalized product (tensor or matrix) of this operation with others.
+        """Construct the generalized product (tensor or matrix)
+        of this operation with others.
 
         The resulting operation acts on the union of all wire sets.
         If the wire sets are disjoint, this is a Kronecker product.
@@ -378,7 +379,9 @@ class Operation:
             mat = mat @ mat_other
 
         op_names = "*".join(op.name for op in all_ops)
-        return Operation(wires=all_wires, matrix=mat, name=f"Prod({op_names})", record=False)
+        return Operation(
+            wires=all_wires, matrix=mat, name=f"Prod({op_names})", record=False
+        )
 
     def __matmul__(self, other: "Operation") -> "Operation":
         """Tensor (Kronecker) product or matrix product of two operations.

--- a/qml_essentials/pulses.py
+++ b/qml_essentials/pulses.py
@@ -57,9 +57,9 @@ class PulseParams:
             decomposition: List of :class:`DecompositionStep` (composite gates).
                 Mutually exclusive with *params*.
         """
-        assert (params is None) != (
-            decomposition is None
-        ), "Exactly one of `params` or `decomposition` must be provided."
+        assert (params is None) != (decomposition is None), (
+            "Exactly one of `params` or `decomposition` must be provided."
+        )
 
         self.decomposition = decomposition
         # Derive _pulse_obj for backward compat with childs/leafs/split_params

--- a/qml_essentials/qoc.py
+++ b/qml_essentials/qoc.py
@@ -55,8 +55,8 @@ class Cost:
         if other is None:
             return lambda *args, **kwargs: self(*args, **kwargs)
         if callable(other):
-            return lambda *args, **kwargs: self(*args, **kwargs) + other(
-                *args, **kwargs
+            return lambda *args, **kwargs: (
+                self(*args, **kwargs) + other(*args, **kwargs)
             )
         raise TypeError(f"Cannot add Cost and {type(other)}")
 
@@ -281,7 +281,7 @@ class CostFnRegistry:
         """
         if name not in cls._REGISTRY:
             raise ValueError(
-                f"Unknown cost function '{name}'. " f"Available: {cls.available()}"
+                f"Unknown cost function '{name}'. Available: {cls.available()}"
             )
         return cls._REGISTRY[name]
 
@@ -326,7 +326,7 @@ class CostFnRegistry:
 
         if got != expected:
             raise ValueError(
-                f"Cost function '{name}' expects {expected} weight(s), " f"got {got}."
+                f"Cost function '{name}' expects {expected} weight(s), got {got}."
             )
 
         return name, weight
@@ -509,9 +509,9 @@ class QOC:
         for name, _weight in cost_fns:
             CostFnRegistry.get(name)  # raises ValueError if unknown
             summed_weights += sum(_weight) if isinstance(_weight, tuple) else _weight
-        assert jnp.isclose(
-            summed_weights, 1.0, rtol=1e-8
-        ), f"Cost function weights must sum to 1. Got {summed_weights}"
+        assert jnp.isclose(summed_weights, 1.0, rtol=1e-8), (
+            f"Cost function weights must sum to 1. Got {summed_weights}"
+        )
 
         self.cost_fns = cost_fns
 
@@ -938,7 +938,8 @@ class QOC:
                     total_costs = _build_cost(name, weight) + total_costs
 
                 fidelity_only_cost = _build_cost(
-                    "fidelity", (1.0, 0.0)  # 100% fidelity, 0% phase
+                    "fidelity",
+                    (1.0, 0.0),  # 100% fidelity, 0% phase
                 )
 
                 best_scan_params = self.stage_0_opt(

--- a/qml_essentials/unitary.py
+++ b/qml_essentials/unitary.py
@@ -151,9 +151,9 @@ class UnitaryGates:
             AssertionError: If noise_params contains "GateError" but random_key is None.
         """
         if noise_params is not None and noise_params.get("GateError", None) is not None:
-            assert (
-                random_key is not None
-            ), "A random_key must be provided when using GateError"
+            assert random_key is not None, (
+                "A random_key must be provided when using GateError"
+            )
 
             if UnitaryGates.batch_gate_error:
                 random_key, sub_key = safe_random_split(random_key)

--- a/qml_essentials/yaqsi.py
+++ b/qml_essentials/yaqsi.py
@@ -571,7 +571,7 @@ class Script:
         except Exception:
             log.debug("Failed to read /proc/meminfo. Falling back to 4 GiB")
 
-        log.debug(f"Available memory: {mem/1024**3:.1f} GB")
+        log.debug(f"Available memory: {mem / 1024**3:.1f} GB")
         return mem
 
     @staticmethod
@@ -1109,8 +1109,7 @@ class Script:
             return jnp.array(results)
 
         raise ValueError(
-            f"Shot simulation is only supported for 'probs' and 'expval', "
-            f"got {type!r}."
+            f"Shot simulation is only supported for 'probs' and 'expval', got {type!r}."
         )
 
     def execute(

--- a/tests/test_ansaetze.py
+++ b/tests/test_ansaetze.py
@@ -35,9 +35,9 @@ def test_gate_gateerror_noise():
     no_noise = script.execute(type="expval", obs=obs, args=({},))
     with_noise = script.execute(type="expval", obs=obs, args=({"GateError": 50},))
 
-    assert np.isclose(
-        no_noise, -1, atol=0.01
-    ), f"Expected ~-1 with no noise, got {no_noise}"
+    assert np.isclose(no_noise, -1, atol=0.01), (
+        f"Expected ~-1 with no noise, got {no_noise}"
+    )
     assert not np.isclose(with_noise, no_noise, atol=0.01), (
         "Expected with noise output to differ, "
         + f"got with noise: {with_noise} and with no noise: {no_noise}"
@@ -61,7 +61,7 @@ def test_batch_gate_error():
     res_b = model(inputs=inputs, noise_params={"GateError": 50})
     # check if each output is the same
     assert np.allclose(res_b, np.flip(res_b)), (
-        "Expected all outputs to be the same " "when batch_gate_error is False"
+        "Expected all outputs to be the same when batch_gate_error is False"
     )
     # Reset to default so other tests are not affected
     UnitaryGates.batch_gate_error = True
@@ -90,12 +90,12 @@ def test_gate_bitflip_noise():
     no_noise = script.execute(type="expval", obs=obs, args=({},))
     with_noise = script.execute(type="expval", obs=obs, args=({"BitFlip": 0.5},))
 
-    assert np.isclose(
-        no_noise, -1, atol=0.1
-    ), f"Expected ~-1 with no noise, got {no_noise}"
-    assert np.isclose(
-        with_noise, 0, atol=0.1
-    ), f"Expected ~0 with noise, got {with_noise}"
+    assert np.isclose(no_noise, -1, atol=0.1), (
+        f"Expected ~-1 with no noise, got {no_noise}"
+    )
+    assert np.isclose(with_noise, 0, atol=0.1), (
+        f"Expected ~0 with noise, got {with_noise}"
+    )
 
 
 @pytest.mark.unittest
@@ -109,12 +109,12 @@ def test_gate_phaseflip_noise():
     no_noise = script.execute(type="expval", obs=obs, args=({},))
     with_noise = script.execute(type="expval", obs=obs, args=({"PhaseFlip": 0.5},))
 
-    assert np.isclose(
-        no_noise, 1, atol=0.1
-    ), f"Expected ~1 with no noise, got {no_noise}"
-    assert np.isclose(
-        with_noise, 0, atol=0.1
-    ), f"Expected ~0 with PhaseFlip noise, got {with_noise}"
+    assert np.isclose(no_noise, 1, atol=0.1), (
+        f"Expected ~1 with no noise, got {no_noise}"
+    )
+    assert np.isclose(with_noise, 0, atol=0.1), (
+        f"Expected ~0 with PhaseFlip noise, got {with_noise}"
+    )
 
 
 @pytest.mark.unittest
@@ -128,12 +128,12 @@ def test_gate_depolarizing_noise():
     no_noise = script.execute(type="expval", obs=obs, args=({},))
     with_noise = script.execute(type="expval", obs=obs, args=({"Depolarizing": 3 / 4},))
 
-    assert np.isclose(
-        no_noise, -1, atol=0.1
-    ), f"Expected ~-1 with no noise, got {no_noise}"
-    assert np.isclose(
-        with_noise, 0, atol=0.1
-    ), f"Expected ~0 with Depolarizing noise, got {with_noise}"
+    assert np.isclose(no_noise, -1, atol=0.1), (
+        f"Expected ~-1 with no noise, got {no_noise}"
+    )
+    assert np.isclose(with_noise, 0, atol=0.1), (
+        f"Expected ~0 with Depolarizing noise, got {with_noise}"
+    )
 
 
 @pytest.mark.unittest
@@ -150,12 +150,12 @@ def test_gate_nqubitdepolarizing_noise():
         type="expval", obs=obs_two, args=({"MultiQubitDepolarizing": 15 / 16},)
     )
 
-    assert np.isclose(
-        no_noise_two, -1, atol=0.1
-    ), f"Expected ~-1 with no noise, got {no_noise_two}"
-    assert np.isclose(
-        with_noise_two, 0, atol=0.1
-    ), f"Expected ~0 with noise, got {with_noise_two}"
+    assert np.isclose(no_noise_two, -1, atol=0.1), (
+        f"Expected ~-1 with no noise, got {no_noise_two}"
+    )
+    assert np.isclose(with_noise_two, 0, atol=0.1), (
+        f"Expected ~0 with noise, got {with_noise_two}"
+    )
 
     def circuit_three(noise_params=None):
         if noise_params is not None:
@@ -173,12 +173,12 @@ def test_gate_nqubitdepolarizing_noise():
         args=({"MultiQubitDepolarizing": 63 / 64},),
     )
 
-    assert np.isclose(
-        no_noise_three, 1, atol=0.1
-    ), f"Expected ~1 with no noise, got {no_noise_three}"
-    assert np.isclose(
-        with_noise_three, 0, atol=0.1
-    ), f"Expected ~0 with noise, got {with_noise_three}"
+    assert np.isclose(no_noise_three, 1, atol=0.1), (
+        f"Expected ~1 with no noise, got {no_noise_three}"
+    )
+    assert np.isclose(with_noise_three, 0, atol=0.1), (
+        f"Expected ~0 with noise, got {with_noise_three}"
+    )
 
 
 @pytest.mark.unittest
@@ -219,9 +219,9 @@ def test_control_angles():
                 ctrl_params, model.params[0, control_params[ansatz] :]
             ), f"Ctrl. params are not returned as expected for circuit {ansatz}."
         else:
-            assert (
-                ctrl_params.size == 0
-            ), f"No ctrl. params expected for circuit {ansatz}"
+            assert ctrl_params.size == 0, (
+                f"No ctrl. params expected for circuit {ansatz}"
+            )
 
 
 @pytest.mark.smoketest
@@ -470,9 +470,9 @@ def test_single_qubit_pulse_gate(gate, w):
 
     fidelity = jnp.abs(jnp.vdot(state_target, state_pulse)) ** 2
     assert fidelity <= 1.0 + 1e-6, f"Fidelity of {gate} can't be larger 1 for w={w}"
-    assert np.isclose(
-        fidelity, 1.0, atol=1e-2
-    ), f"Fidelity too low for w={w}: {fidelity}"
+    assert np.isclose(fidelity, 1.0, atol=1e-2), (
+        f"Fidelity too low for w={w}: {fidelity}"
+    )
 
     phase_diff = np.angle(np.vdot(state_target, state_pulse))
     assert np.isclose(phase_diff, 0.0, atol=1e-2), f"Phase off for w={w}: {phase_diff}"
@@ -498,9 +498,9 @@ def test_two_qubit_pulse_gate(gate, w):
 
     fidelity = jnp.abs(jnp.vdot(state_target, state_pulse)) ** 2
     assert fidelity <= 1.0 + 1e-6, f"Fidelity of {gate} can't be larger 1 for w={w}"
-    assert np.isclose(
-        fidelity, 1.0, atol=1e-2
-    ), f"Fidelity too low for w={w}: {fidelity}"
+    assert np.isclose(fidelity, 1.0, atol=1e-2), (
+        f"Fidelity too low for w={w}: {fidelity}"
+    )
 
     phase_diff = np.angle(np.vdot(state_target, state_pulse))
     assert np.isclose(phase_diff, 0.0, atol=1e-2), f"Phase off for w={w}: {phase_diff}"

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -45,16 +45,16 @@ class TestCoefficients:
         coeffs, freqs = Coefficients.get_spectrum(model)
 
         assert coeffs.shape == model.degree, "Wrong number of coefficients"
-        assert jnp.isclose(
-            jnp.sum(coeffs).imag, 0.0, rtol=1.0e-5
-        ), "Imaginary part is not zero"
+        assert jnp.isclose(jnp.sum(coeffs).imag, 0.0, rtol=1.0e-5), (
+            "Imaginary part is not zero"
+        )
 
         partial_circuit = partial(model, model.params, force_mean=True)
         ref_coeffs = pcoefficients(partial_circuit, 1, model.degree[0] // 2)
 
-        assert jnp.allclose(
-            coeffs, ref_coeffs, rtol=1.0e-5
-        ), "Coefficients don't match the pennylane reference"
+        assert jnp.allclose(coeffs, ref_coeffs, rtol=1.0e-5), (
+            "Coefficients don't match the pennylane reference"
+        )
 
         for ref_input in reference_inputs:
             exp_model = model(params=None, inputs=ref_input, force_mean=True)
@@ -65,9 +65,9 @@ class TestCoefficients:
                 inputs=ref_input,
             )
 
-            assert jnp.isclose(
-                exp_model, exp_fourier, atol=1.0e-5
-            ), "Fourier series does not match model expectation"
+            assert jnp.isclose(exp_model, exp_fourier, atol=1.0e-5), (
+                "Fourier series does not match model expectation"
+            )
 
     @pytest.mark.unittest
     def test_dummy_model(self) -> None:
@@ -110,12 +110,12 @@ class TestCoefficients:
             model_fct, mts=mts, shift=True, trim=True
         )
 
-        assert jnp.allclose(
-            X2_shift, X_shift, atol=1.0e-5
-        ), "Model and dummy coefficients are not equal."
-        assert jnp.allclose(
-            X2_freq_shift, X_freq_shift, atol=1.0e-5
-        ), "Model and dummy frequencies are not equal."
+        assert jnp.allclose(X2_shift, X_shift, atol=1.0e-5), (
+            "Model and dummy coefficients are not equal."
+        )
+        assert jnp.allclose(X2_freq_shift, X_freq_shift, atol=1.0e-5), (
+            "Model and dummy frequencies are not equal."
+        )
 
     @pytest.mark.unittest
     @pytest.mark.parametrize(
@@ -153,9 +153,9 @@ class TestCoefficients:
             inputs=ref_input,
         )
 
-        assert jnp.isclose(
-            exp_model, exp_fourier, atol=1.0e-5
-        ).all(), "Fourier series does not match model expectation"
+        assert jnp.isclose(exp_model, exp_fourier, atol=1.0e-5).all(), (
+            "Fourier series does not match model expectation"
+        )
 
     @pytest.mark.smoketest
     def test_batch(self) -> None:
@@ -181,9 +181,9 @@ class TestCoefficients:
             coeffs_single, _ = Coefficients.get_spectrum(
                 model, params=params[i], shift=True, trim=True
             )
-            assert jnp.allclose(
-                coeffs_parallel[:, i], coeffs_single, rtol=1.0e-5
-            ), "MP and SP coefficients don't match for 1D input"
+            assert jnp.allclose(coeffs_parallel[:, i], coeffs_single, rtol=1.0e-5), (
+                "MP and SP coefficients don't match for 1D input"
+            )
 
         model = Model(
             n_qubits=2,
@@ -201,9 +201,9 @@ class TestCoefficients:
             coeffs_single, _ = Coefficients.get_spectrum(
                 model, params=params[i], shift=True, trim=True
             )
-            assert jnp.allclose(
-                coeffs_parallel[:, :, i], coeffs_single, rtol=1.0e-5
-            ), "MP and SP coefficients don't match for 2D input"
+            assert jnp.allclose(coeffs_parallel[:, :, i], coeffs_single, rtol=1.0e-5), (
+                "MP and SP coefficients don't match for 2D input"
+            )
 
     @pytest.mark.unittest
     def test_oversampling_time(self) -> None:
@@ -213,9 +213,9 @@ class TestCoefficients:
             circuit_type="Circuit_19",
         )
 
-        assert (
-            Coefficients.get_spectrum(model, mts=3)[0].shape[0] == 15
-        ), "Oversampling time failed"
+        assert Coefficients.get_spectrum(model, mts=3)[0].shape[0] == 15, (
+            "Oversampling time failed"
+        )
 
     @pytest.mark.unittest
     def test_oversampling_frequency(self) -> None:
@@ -225,9 +225,9 @@ class TestCoefficients:
             circuit_type="Circuit_19",
         )
 
-        assert (
-            Coefficients.get_spectrum(model, mfs=3)[0].shape[0] == 15
-        ), "Oversampling frequency failed"
+        assert Coefficients.get_spectrum(model, mfs=3)[0].shape[0] == 15, (
+            "Oversampling frequency failed"
+        )
 
     @pytest.mark.unittest
     def test_shift(self) -> None:
@@ -238,9 +238,9 @@ class TestCoefficients:
         )
         coeffs, freqs = Coefficients.get_spectrum(model, shift=True)
 
-        assert (
-            jnp.abs(coeffs) == jnp.abs(coeffs[::-1])
-        ).all(), "Shift failed. Spectrum must be symmetric."
+        assert (jnp.abs(coeffs) == jnp.abs(coeffs[::-1])).all(), (
+            "Shift failed. Spectrum must be symmetric."
+        )
 
     @pytest.mark.unittest
     def test_trim(self) -> None:
@@ -254,10 +254,10 @@ class TestCoefficients:
         coeffs, freqs = Coefficients.get_spectrum(model, mts=2, trim=False)
         coeffs_trimmed, freqs = Coefficients.get_spectrum(model, mts=2, trim=True)
 
-        assert (
-            coeffs.size - 1 == coeffs_trimmed.size
-        ), f"Wrong shape of coefficients: {coeffs_trimmed.size}, \
+        assert coeffs.size - 1 == coeffs_trimmed.size, (
+            f"Wrong shape of coefficients: {coeffs_trimmed.size}, \
             expected {coeffs.size - 1}"
+        )
 
     @pytest.mark.unittest
     def test_frequencies(self) -> None:
@@ -268,10 +268,10 @@ class TestCoefficients:
         )
         coeffs, freqs = Coefficients.get_spectrum(model)
 
-        assert (
-            freqs.shape == coeffs.shape
-        ), f"(1D) Frequencies ({freqs.shape}) and \
+        assert freqs.shape == coeffs.shape, (
+            f"(1D) Frequencies ({freqs.shape}) and \
             coefficients ({coeffs.shape}) must have the same length."
+        )
 
         # 2d
 
@@ -283,10 +283,10 @@ class TestCoefficients:
         )
         coeffs, freqs = Coefficients.get_spectrum(model)
 
-        assert (
-            freqs[0].size * freqs[1].size
-        ) == coeffs.size, f"(2D) Frequencies ({freqs.shape}) and \
+        assert (freqs[0].size * freqs[1].size) == coeffs.size, (
+            f"(2D) Frequencies ({freqs.shape}) and \
             coefficients ({coeffs.shape}) must add up to the same length."
+        )
 
         # uneven 2d
 
@@ -302,10 +302,10 @@ class TestCoefficients:
         )
         coeffs, freqs = Coefficients.get_spectrum(model)
 
-        assert (
-            freqs[0].size * freqs[1].size
-        ) == coeffs.size, f"(2D) Frequencies ({freqs.shape}) and \
+        assert (freqs[0].size * freqs[1].size) == coeffs.size, (
+            f"(2D) Frequencies ({freqs.shape}) and \
             coefficients ({coeffs.shape}) must add up to the same length."
+        )
 
     @pytest.mark.smoketest
     def test_psd(self) -> None:
@@ -351,9 +351,9 @@ class TestFourierTree:
         analytical_coeffs, analytical_freqs = coeff_tree.get_spectrum()
         analytical_coeffs = jnp.stack(analytical_coeffs).T
 
-        assert jnp.isclose(
-            jnp.sum(analytical_coeffs).imag, 0.0, rtol=1.0e-5
-        ), "Imaginary part is not zero"
+        assert jnp.isclose(jnp.sum(analytical_coeffs).imag, 0.0, rtol=1.0e-5), (
+            "Imaginary part is not zero"
+        )
 
         # Filter fft_coeffs for only the frequencies that occur in the spectrum
         greater_zeros = jnp.invert(jnp.isclose(fft_coeffs, 0.0))
@@ -381,13 +381,13 @@ class TestFourierTree:
 
             exp_tree = coeff_tree(inputs=ref_input)
 
-            assert jnp.isclose(
-                exp_fourier_fft, exp_fourier, atol=1.0e-5
-            ).all(), "FFT and analytical Fourier series do not match"
+            assert jnp.isclose(exp_fourier_fft, exp_fourier, atol=1.0e-5).all(), (
+                "FFT and analytical Fourier series do not match"
+            )
 
-            assert jnp.isclose(
-                exp_tree, exp_fourier, atol=1.0e-5
-            ).all(), "Analytic Fourier series evaluation not working"
+            assert jnp.isclose(exp_tree, exp_fourier, atol=1.0e-5).all(), (
+                "Analytic Fourier series evaluation not working"
+            )
 
     @pytest.mark.unittest
     def test_coefficients_tree_mq(self) -> None:
@@ -406,9 +406,9 @@ class TestFourierTree:
         analytical_coeffs, analytical_freqs = coeff_tree.get_spectrum(force_mean=True)
         analytical_coeffs = jnp.stack(analytical_coeffs).T
 
-        assert jnp.isclose(
-            jnp.sum(analytical_coeffs).imag, 0.0, rtol=1.0e-5
-        ), "Imaginary part is not zero"
+        assert jnp.isclose(jnp.sum(analytical_coeffs).imag, 0.0, rtol=1.0e-5), (
+            "Imaginary part is not zero"
+        )
 
         # Filter fft_coeffs for only the frequencies that occur in the spectrum
         greater_zeros = jnp.invert(jnp.isclose(fft_coeffs, 0.0))
@@ -436,13 +436,13 @@ class TestFourierTree:
 
             exp_tree = coeff_tree(inputs=ref_input, force_mean=True)
 
-            assert jnp.isclose(
-                exp_fourier_fft, exp_fourier, atol=1.0e-5
-            ), "FFT and analytical Fourier series do not match"
+            assert jnp.isclose(exp_fourier_fft, exp_fourier, atol=1.0e-5), (
+                "FFT and analytical Fourier series do not match"
+            )
 
-            assert jnp.isclose(
-                exp_tree, exp_fourier, atol=1.0e-5
-            ), "Analytic Fourier series evaluation not working"
+            assert jnp.isclose(exp_tree, exp_fourier, atol=1.0e-5), (
+                "Analytic Fourier series evaluation not working"
+            )
 
 
 class TestFCC:
@@ -578,9 +578,9 @@ class TestFCC:
         )
         fcc = FCC.get_fcc(model=model, n_samples=500, scale=True)
 
-        assert jnp.isclose(
-            fcc, expected_fcc, atol=3.0e-2
-        ), f"Wrong FCC for {circuit_type}. Got {fcc}, expected {expected_fcc}."
+        assert jnp.isclose(fcc, expected_fcc, atol=3.0e-2), (
+            f"Wrong FCC for {circuit_type}. Got {fcc}, expected {expected_fcc}."
+        )
 
     @pytest.mark.unittest
     @pytest.mark.parametrize(
@@ -635,9 +635,9 @@ class TestFCC:
             fcc = FCC.get_fcc(
                 model, n_samples=n_samples, method=method, trim_redundant=True
             )
-            assert (
-                0.0 <= float(fcc) <= 1.0
-            ), f"FCC out of [0, 1] for {encoding_strategy}/{method}: {float(fcc)}"
+            assert 0.0 <= float(fcc) <= 1.0, (
+                f"FCC out of [0, 1] for {encoding_strategy}/{method}: {float(fcc)}"
+            )
 
             # Also test without trimming
             fcc_untrimmed = FCC.get_fcc(
@@ -695,9 +695,9 @@ class TestFCC:
             n_samples=250,
             scale=True,
         )
-        assert jnp.isclose(
-            fcc, 0.016, atol=2.0e-3
-        ), f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.020."
+        assert jnp.isclose(fcc, 0.016, atol=2.0e-3), (
+            f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.020."
+        )
 
     @pytest.mark.unittest
     def test_weighting(self) -> None:
@@ -724,9 +724,9 @@ class TestFCC:
             scale=True,
             weight=True,
         )
-        assert jnp.isclose(
-            fcc, 0.010, atol=5.0e-3
-        ), f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.010."
+        assert jnp.isclose(fcc, 0.010, atol=5.0e-3), (
+            f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.010."
+        )
 
 
 class TestDatasets:
@@ -824,12 +824,12 @@ class TestDatasets:
                     model.n_input_feat,
                 )
             ), f"Wrong shape of domain samples: {domain_samples.shape}"
-            assert jnp.all(
-                fourier_samples.shape == model.degree
-            ), f"Wrong shape of Fourier values: {fourier_samples.shape}"
-            assert jnp.all(
-                coefficients.shape == model.degree
-            ), f"Wrong shape of coefficients: {coefficients.shape}"
+            assert jnp.all(fourier_samples.shape == model.degree), (
+                f"Wrong shape of Fourier values: {fourier_samples.shape}"
+            )
+            assert jnp.all(coefficients.shape == model.degree), (
+                f"Wrong shape of coefficients: {coefficients.shape}"
+            )
 
             all_domain_samples.append(domain_samples)
             all_fourier_samples.append(fourier_samples)
@@ -840,13 +840,13 @@ class TestDatasets:
         all_coefficients = jnp.array(all_coefficients)
 
         if not zero_centered:
-            assert jnp.sqrt(coefficients_min) <= jnp.min(
-                jnp.abs(coefficients)
-            ), "Coefficients are too small"
-            assert jnp.sqrt(coefficients_max) >= jnp.max(
-                jnp.abs(coefficients)
-            ), "Coefficients are too large"
+            assert jnp.sqrt(coefficients_min) <= jnp.min(jnp.abs(coefficients)), (
+                "Coefficients are too small"
+            )
+            assert jnp.sqrt(coefficients_max) >= jnp.max(jnp.abs(coefficients)), (
+                "Coefficients are too large"
+            )
         else:
-            assert jnp.isclose(
-                fourier_samples.mean(), 0.0, atol=1e-1
-            ), "Zero centering failed"
+            assert jnp.isclose(fourier_samples.mean(), 0.0, atol=1e-1), (
+                "Zero centering failed"
+            )

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -625,9 +625,7 @@ class TestFCC:
         )
 
         fp_spearman = FCC._correlate(coeffs.transpose(), method="spearman")
-        assert np.all(
-            np.abs(fp_spearman[np.isfinite(fp_spearman)]) <= 1.0 + 1e-10
-        ), (
+        assert np.all(np.abs(fp_spearman[np.isfinite(fp_spearman)]) <= 1.0 + 1e-10), (
             f"Spearman correlation out of [-1, 1] for {encoding_strategy}. "
             f"Max |rho| = {np.max(np.abs(fp_spearman[np.isfinite(fp_spearman)]))}"
         )
@@ -637,9 +635,9 @@ class TestFCC:
             fcc = FCC.get_fcc(
                 model, n_samples=n_samples, method=method, trim_redundant=True
             )
-            assert 0.0 <= float(fcc) <= 1.0, (
-                f"FCC out of [0, 1] for {encoding_strategy}/{method}: {float(fcc)}"
-            )
+            assert (
+                0.0 <= float(fcc) <= 1.0
+            ), f"FCC out of [0, 1] for {encoding_strategy}/{method}: {float(fcc)}"
 
             # Also test without trimming
             fcc_untrimmed = FCC.get_fcc(

--- a/tests/test_entanglement.py
+++ b/tests/test_entanglement.py
@@ -156,11 +156,11 @@ def test_mw_measure() -> None:
             + f"Expected Result: {test_case['result']},\t"
             + f"Error: {error}"
         )
-        assert (
-            error < tolerance
-        ), f"Entangling-capability of circuit {test_case['circuit_type']} is not\
+        assert error < tolerance, (
+            f"Entangling-capability of circuit {test_case['circuit_type']} is not\
             {test_case['result']} but {ent_cap} instead.\
             Deviation {(error * 100):.1f}%>{tolerance * 100}%"
+        )
 
     references = sorted(
         [
@@ -259,11 +259,11 @@ def test_bell_measure() -> None:
             + f"Expected Result: {test_case['result']},\t"
             + f"Error: {error}"
         )
-        assert (
-            error < tolerance
-        ), f"Entangling-capability of circuit {test_case['circuit_type']} is not\
+        assert error < tolerance, (
+            f"Entangling-capability of circuit {test_case['circuit_type']} is not\
             {test_case['result']} but {ent_cap} instead.\
             Deviation {(error * 100):.1f}%>{tolerance * 100}%"
+        )
 
     references = sorted(
         [
@@ -371,8 +371,10 @@ def test_relative_entropy_order() -> None:
 
     assert all(
         entanglement[i] <= entanglement[i + 1] for i in range(len(entanglement) - 1)
-    ), f"Order of entanglement should be\
+    ), (
+        f"Order of entanglement should be\
         {[(c, ent) for c, ent in zip(circuits, entanglement, strict=True)]}."
+    )
 
 
 @pytest.mark.smoketest
@@ -399,8 +401,10 @@ def test_entanglement_of_formation_order() -> None:
 
     assert all(
         entanglement[i] <= entanglement[i + 1] for i in range(len(entanglement) - 1)
-    ), f"Order of entanglement should be\
+    ), (
+        f"Order of entanglement should be\
         {[(c, ent) for c, ent in zip(circuits, entanglement, strict=True)]}."
+    )
 
 
 @pytest.mark.smoketest
@@ -427,8 +431,10 @@ def test_concentratable_entanglement_order() -> None:
 
     assert all(
         entanglement[i] <= entanglement[i + 1] for i in range(len(entanglement) - 1)
-    ), f"Order of entanglement should be\
+    ), (
+        f"Order of entanglement should be\
         {[(c, ent) for c, ent in zip(circuits, entanglement, strict=True)]}."
+    )
 
 
 @pytest.mark.smoketest
@@ -455,5 +461,7 @@ def test_concentratable_entanglement_estimation_order() -> None:
 
     assert all(
         entanglement[i] <= entanglement[i + 1] for i in range(len(entanglement) - 1)
-    ), f"Order of entanglement should be\
+    ), (
+        f"Order of entanglement should be\
         {[(c, ent) for c, ent in zip(circuits, entanglement, strict=True)]}."
+    )

--- a/tests/test_expressiblity.py
+++ b/tests/test_expressiblity.py
@@ -106,9 +106,9 @@ def test_divergence() -> None:
         # Calculate the mean (over all inputs, if required)
         kl_dist = Expressibility.kullback_leibler_divergence(y_haar_a, y_haar_b).mean()
 
-        assert math.isclose(
-            kl_dist.mean(), test_case["result"], abs_tol=1e-3
-        ), "Distance between two identical haar measures not equal."
+        assert math.isclose(kl_dist.mean(), test_case["result"], abs_tol=1e-3), (
+            "Distance between two identical haar measures not equal."
+        )
 
 
 @pytest.mark.unittest
@@ -163,11 +163,11 @@ def test_expressibility(layers) -> None:
             + f"Expected Result: {test_case['result']},\t"
             + f"Error: {(error * 100):.1f}%"
         )
-        assert (
-            error < tolerance
-        ), f"Expressibility of circuit {test_case['circuit_type']} is not\
+        assert error < tolerance, (
+            f"Expressibility of circuit {test_case['circuit_type']} is not\
             {test_case['result']} but {kl_dist} instead.\
             Deviation {(error * 100):.1f}% > {tolerance * 100}%"
+        )
 
     references = sorted(
         [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -55,9 +55,9 @@ def test_trainable_frequencies() -> None:
     model.params, model.enc_params = optax.apply_updates(all_params, updates)
     enc_params_after = model.enc_params.copy()
 
-    assert not jnp.allclose(
-        enc_params_before, enc_params_after
-    ), "enc_params did not update during training"
+    assert not jnp.allclose(enc_params_before, enc_params_after), (
+        "enc_params did not update during training"
+    )
 
     assert jnp.any(jnp.abs(grads[1]) > 1e-6), "Gradient wrt enc_params is too small"
 
@@ -92,13 +92,13 @@ def test_transform_input() -> None:
     assert jnp.allclose(result, expected), "Incorrect transform for qubit 0"
 
     # Test modified transform_input()
-    model.transform_input = lambda inputs, enc_params: (jnp.arccos(inputs))
+    model.transform_input = lambda inputs, enc_params: jnp.arccos(inputs)
 
     result_new = model(model.params, x, pulse_params=None)
 
-    assert jnp.allclose(
-        x, result_new
-    ), "model.transform_input does not work as intended"
+    assert jnp.allclose(x, result_new), (
+        "model.transform_input does not work as intended"
+    )
 
 
 @pytest.mark.unittest
@@ -123,9 +123,9 @@ def test_batching() -> None:
         res[i] = model(params=params[i], execution_type="density")
 
     assert res.shape == (n_samples, 4, 4), "Shape of batching is not correct"
-    assert jnp.allclose(
-        res, model(params=params, execution_type="density")
-    ), "Content of batching is not equal"
+    assert jnp.allclose(res, model(params=params, execution_type="density")), (
+        "Content of batching is not equal"
+    )
 
 
 @pytest.mark.unittest
@@ -183,9 +183,9 @@ def test_multiprocessing_expval() -> None:
     # ), "Time required for multiprocessing larger than single process"
 
     print(f"Diff: {t_parallel - t_single}")
-    assert (
-        res_parallel.shape == res_single.shape
-    ), "Shape of multiprocessing is not correct"
+    assert res_parallel.shape == res_single.shape, (
+        "Shape of multiprocessing is not correct"
+    )
     assert (res_parallel == res_single).all(), "Content of multiprocessing is not equal"
 
 
@@ -309,10 +309,10 @@ def test_encoding() -> None:
                 inputs=test_case["input"],
             )
 
-        assert (
-            model.degree == test_case["degree"]
-        ), f"Frequencies is not correct: got {model.degree},\
+        assert model.degree == test_case["degree"], (
+            f"Frequencies is not correct: got {model.degree},\
             expected {test_case['degree']} for test case {test_case}"
+        )
 
 
 @pytest.mark.smoketest
@@ -480,9 +480,9 @@ def test_re_initialization() -> None:
 
     model.initialize_params(random.key(1001))
 
-    assert not jnp.allclose(
-        model.params, temp_params, atol=1e-3
-    ), "Re-Initialization failed!"
+    assert not jnp.allclose(model.params, temp_params, atol=1e-3), (
+        "Re-Initialization failed!"
+    )
 
 
 @pytest.mark.unittest
@@ -529,9 +529,9 @@ def test_pulse_model() -> None:
 
     pulse_params_after = model.pulse_params.copy()
 
-    assert not jnp.allclose(
-        pulse_params_before, pulse_params_after
-    ), "pulse_params did not update during training"
+    assert not jnp.allclose(pulse_params_before, pulse_params_after), (
+        "pulse_params did not update during training"
+    )
 
     assert jnp.any(jnp.abs(grads[1]) > 1e-6), "Gradient wrt pulse_params is too small"
 
@@ -551,9 +551,9 @@ def test_pulse_model_inference():
 
     y_hat_unitary = model(inputs=inputs, gate_mode="unitary", force_mean=True)
 
-    assert jnp.allclose(
-        y_hat_unitary, y_hat_original, atol=1e-3
-    ), "Unitary output did not match pulse output"
+    assert jnp.allclose(y_hat_unitary, y_hat_original, atol=1e-3), (
+        "Unitary output did not match pulse output"
+    )
 
     # perturb pulse_params
     original_params = model.pulse_params.copy()
@@ -565,9 +565,9 @@ def test_pulse_model_inference():
     assert y_hat_original.shape[0] == inputs.shape[0], "Output batch size mismatch"
 
     # ensure output changed after perturbing pulse_params
-    assert not jnp.allclose(
-        y_hat_original, y_hat_perturbed
-    ), "Pulse output did not change after modifying pulse_params"
+    assert not jnp.allclose(y_hat_original, y_hat_perturbed), (
+        "Pulse output did not change after modifying pulse_params"
+    )
 
     model.pulse_params = original_params
 
@@ -594,9 +594,9 @@ def test_pulse_model_batching():
     res_b = model(inputs=inputs, gate_mode="pulse")
 
     assert np.allclose(res_a.shape, res_b.shape), "Batch shape mismatch"
-    assert jnp.allclose(
-        res_a, res_b, atol=1e-2
-    ), "Inputs batching failed. Results differ."
+    assert jnp.allclose(res_a, res_b, atol=1e-2), (
+        "Inputs batching failed. Results differ."
+    )
 
     model.initialize_params(random_key, repeat=2)
 
@@ -605,9 +605,9 @@ def test_pulse_model_batching():
     res_b = model(inputs=inputs, gate_mode="pulse")
 
     assert np.allclose(res_a.shape, res_b.shape), "Batch shape mismatch"
-    assert jnp.allclose(
-        res_a, res_b, atol=1e-2
-    ), "Params batching failed. Results differ."
+    assert jnp.allclose(res_a, res_b, atol=1e-2), (
+        "Params batching failed. Results differ."
+    )
 
 
 @pytest.mark.unittest
@@ -656,9 +656,9 @@ def test_multi_input() -> None:
                     f"as an output dimension, but got {out.shape[0]}"
                 )
             else:
-                assert (
-                    inputs.shape[0] == 1
-                ), "expected one elemental input for zero dimensional output"
+                assert inputs.shape[0] == 1, (
+                    "expected one elemental input for zero dimensional output"
+                )
         else:
             assert len(out.shape) == 0, "expected one elemental output for empty input"
 
@@ -700,10 +700,10 @@ def test_dru() -> None:
             shots=1024,
         )
 
-        assert (
-            model.degree == test_case["degree"]
-        ), f"Expected frequencies {test_case['degree']} but got\
+        assert model.degree == test_case["degree"], (
+            f"Expected frequencies {test_case['degree']} but got\
             {model.degree} for dru {test_case['dru']}"
+        )
 
         _ = model(
             model.params,
@@ -917,10 +917,10 @@ def test_output_shapes() -> None:
                 execution_type=test_case["execution_type"],
             )
 
-        assert (
-            out.shape == test_case["out_shape"]
-        ), f"Expected {test_case['out_shape']}, got shape {out.shape}\
+        assert out.shape == test_case["out_shape"], (
+            f"Expected {test_case['out_shape']}, got shape {out.shape}\
             for test case {test_case}"
+        )
 
 
 @pytest.mark.unittest
@@ -943,9 +943,9 @@ def test_parity() -> None:
         params=model_a.params, inputs=None, force_mean=True
     )  # use same params!
 
-    assert not jnp.allclose(
-        result_a, result_b
-    ), f"Models should be different! Got {result_a} and {result_b}"
+    assert not jnp.allclose(result_a, result_b), (
+        f"Models should be different! Got {result_a} and {result_b}"
+    )
 
 
 @pytest.mark.smoketest

--- a/tests/test_yaqsi.py
+++ b/tests/test_yaqsi.py
@@ -1378,7 +1378,7 @@ class TestGateOperations:
 
     @pytest.mark.unittest
     def test_prod_function(self):
-        """Module-level prod function constructs generalized product 
+        """Module-level prod function constructs generalized product
         (tensor or matrix) of multiple operations."""
         x = PauliX(wires=0, record=False)
         y = PauliY(wires=1, record=False)

--- a/tests/test_yaqsi.py
+++ b/tests/test_yaqsi.py
@@ -185,9 +185,9 @@ class TestEvolve:
         script_p = Script(f=param_circuit)
         state_param = script_p.execute(type="state", args=(T_val,))
 
-        assert jnp.allclose(
-            state_static, state_param, atol=1e-6
-        ), f"Static: {state_static}, Param: {state_param}"
+        assert jnp.allclose(state_static, state_param, atol=1e-6), (
+            f"Static: {state_static}, Param: {state_param}"
+        )
 
     @pytest.mark.unittest
     def test_evolve_parametrized_unitarity(self) -> None:
@@ -232,9 +232,9 @@ class TestEvolve:
         # ⟨X⟩ = cos(2p) for H exp(-ipZ)|0⟩, so d⟨X⟩/dp = -2 sin(2p)
         grad = jax.grad(cost)(p_val)
         expected_grad = -2.0 * jnp.sin(2.0 * p_val)
-        assert jnp.allclose(
-            grad, expected_grad, atol=1e-4
-        ), f"Grad: {grad}, expected: {expected_grad}"
+        assert jnp.allclose(grad, expected_grad, atol=1e-4), (
+            f"Grad: {grad}, expected: {expected_grad}"
+        )
 
     @pytest.mark.unittest
     def test_evolve_parametrized_on_tape(self) -> None:
@@ -426,7 +426,6 @@ class TestMeasurement:
 
 
 class TestPennylane:
-
     @pytest.mark.unittest
     @pytest.mark.parametrize(
         "gate_name,yaqsi_gate,pl_gate,theta,prep_both",
@@ -466,9 +465,9 @@ class TestPennylane:
         probs_ours = np.array(script.execute(type="probs"))
         probs_pl = _pennylane_probs(pl_circuit)
 
-        assert np.allclose(
-            probs_ours, probs_pl, atol=1e-10
-        ), f"{gate_name} mismatch:\nours = {probs_ours}\nPL   = {probs_pl}"
+        assert np.allclose(probs_ours, probs_pl, atol=1e-10), (
+            f"{gate_name} mismatch:\nours = {probs_ours}\nPL   = {probs_pl}"
+        )
 
     @pytest.mark.unittest
     def test_rot_matches_pennylane(self) -> None:
@@ -485,9 +484,9 @@ class TestPennylane:
         probs_ours = np.array(script.execute(type="probs"))
         probs_pl = _pennylane_probs(pl_circuit, n_qubits=1)
 
-        assert np.allclose(
-            probs_ours, probs_pl, atol=1e-10
-        ), f"Rot mismatch:\nours = {probs_ours}\nPL   = {probs_pl}"
+        assert np.allclose(probs_ours, probs_pl, atol=1e-10), (
+            f"Rot mismatch:\nours = {probs_ours}\nPL   = {probs_pl}"
+        )
 
     @pytest.mark.unittest
     def test_rot_decomposition_matches_individual_gates(self) -> None:
@@ -514,9 +513,9 @@ class TestPennylane:
             if abs(state_dec[0]) > 1e-10
             else state_rot[1] / state_dec[1]
         )
-        assert np.allclose(
-            state_rot, phase * state_dec, atol=1e-10
-        ), f"Rot decomposition mismatch:\nrot = {state_rot}\ndec = {state_dec}"
+        assert np.allclose(state_rot, phase * state_dec, atol=1e-10), (
+            f"Rot decomposition mismatch:\nrot = {state_rot}\ndec = {state_dec}"
+        )
 
 
 class TestNoise:
@@ -569,9 +568,9 @@ class TestNoise:
         rho_ours = np.array(script.execute(type="density", args=(jnp.array(theta),)))
         rho_pl = _pennylane_density(pl_circuit)
 
-        assert np.allclose(
-            rho_ours, rho_pl, atol=atol
-        ), f"{channel_name} mismatch:\nours =\n{rho_ours}\nPL =\n{rho_pl}"
+        assert np.allclose(rho_ours, rho_pl, atol=atol), (
+            f"{channel_name} mismatch:\nours =\n{rho_ours}\nPL =\n{rho_pl}"
+        )
 
     @pytest.mark.unittest
     def test_thermal_relaxation_t2_le_t1_matches_pennylane(self) -> None:
@@ -591,9 +590,9 @@ class TestNoise:
         rho_ours = np.array(script.execute(type="density", args=(jnp.array(theta),)))
         rho_pl = _pennylane_density(pl_circuit)
 
-        assert np.allclose(
-            rho_ours, rho_pl, atol=1e-7
-        ), f"ThermalRelaxation (T2≤T1) mismatch:\nours =\n{rho_ours}\nPL =\n{rho_pl}"
+        assert np.allclose(rho_ours, rho_pl, atol=1e-7), (
+            f"ThermalRelaxation (T2≤T1) mismatch:\nours =\n{rho_ours}\nPL =\n{rho_pl}"
+        )
 
     @pytest.mark.unittest
     def test_noise_auto_routes_to_density(self) -> None:
@@ -654,9 +653,9 @@ class TestBatch:
             in_axes=(0,),
         )
 
-        assert (
-            batched.shape == sequential.shape
-        ), f"Shape mismatch: batched {batched.shape} vs sequential {sequential.shape}"
+        assert batched.shape == sequential.shape, (
+            f"Shape mismatch: batched {batched.shape} vs sequential {sequential.shape}"
+        )
         assert jnp.allclose(batched, sequential, atol=1e-6)
 
     @pytest.mark.unittest
@@ -1012,7 +1011,7 @@ def test_mode_performances(benchmark, mode, speedup) -> None:
 
     logger.info(
         f"Yaqsi {mode} ({n_qubits}q, batch={batch_size}, avg {n_iters}): "
-        f"{t_ys*1000:.2f} ± {std_ys*1000:.2f} ms"
+        f"{t_ys * 1000:.2f} ± {std_ys * 1000:.2f} ms"
     )
 
     # --- PennyLane ---
@@ -1049,13 +1048,13 @@ def test_mode_performances(benchmark, mode, speedup) -> None:
 
     logger.info(
         f"PennyLane {mode} ({n_qubits}q, batch={batch_size}, avg {n_iters}): "
-        f"{t_pl*1000:.2f} ± {std_pl*1000:.2f} ms"
+        f"{t_pl * 1000:.2f} ± {std_pl * 1000:.2f} ms"
     )
     ratio = t_pl / t_ys
     logger.info(f"Ratio pl/yaqsi: {ratio:.2f}x")
-    assert (
-        ratio >= speedup
-    ), f"Yaqsi not significantly faster than PennyLane. {ratio:2f}x"
+    assert ratio >= speedup, (
+        f"Yaqsi not significantly faster than PennyLane. {ratio:2f}x"
+    )
 
     res_pl_arr = jnp.array(res_pl)
     if res_pl_arr.shape != res_ys.shape:
@@ -1105,9 +1104,9 @@ class TestShots:
         sampled = script.execute(
             type="expval", obs=obs, args=(0.5,), shots=100000, key=key
         )
-        assert (
-            sampled.shape == exact.shape
-        ), f"Shape mismatch: {sampled.shape} vs {exact.shape}"
+        assert sampled.shape == exact.shape, (
+            f"Shape mismatch: {sampled.shape} vs {exact.shape}"
+        )
         assert jnp.allclose(exact, sampled, atol=0.02), (
             f"Shot expval doesn't converge to exact.\n"
             f"  exact:   {exact}\n"
@@ -1162,9 +1161,9 @@ class TestShots:
         assert result.shape == (4, 4), f"Expected shape (4, 4), got {result.shape}"
         # Each row should sum to 1
         row_sums = result.sum(axis=1)
-        assert jnp.allclose(
-            row_sums, 1.0, atol=1e-10
-        ), f"Batched probs don't sum to 1: {row_sums}"
+        assert jnp.allclose(row_sums, 1.0, atol=1e-10), (
+            f"Batched probs don't sum to 1: {row_sums}"
+        )
 
     @pytest.mark.unittest
     def test_shots_expval_batched(self):
@@ -1214,9 +1213,9 @@ class TestShots:
             shots=100,
             key=jax.random.PRNGKey(0),
         )
-        assert jnp.allclose(
-            exact, with_shots
-        ), "shots should be ignored for 'state' type"
+        assert jnp.allclose(exact, with_shots), (
+            "shots should be ignored for 'state' type"
+        )
 
 
 class TestGateOperations:
@@ -1303,9 +1302,9 @@ class TestGateOperations:
         x = PauliX(wires=0, record=False)
         z = PauliZ(wires=0, record=False)
         result = x + z
-        assert jnp.allclose(
-            result.matrix, jnp.conj(result.matrix).T, atol=1e-10
-        ), "Sum of Hermitian operators should be Hermitian"
+        assert jnp.allclose(result.matrix, jnp.conj(result.matrix).T, atol=1e-10), (
+            "Sum of Hermitian operators should be Hermitian"
+        )
 
     @pytest.mark.unittest
     def test_add_different_wires_raises(self):
@@ -1352,7 +1351,8 @@ class TestGateOperations:
 
     @pytest.mark.unittest
     def test_matmul_partial_overlap(self):
-        """Tensor product with partially overlapping wires produces embedded matrix multiplication."""
+        """Tensor product with partially overlapping wires
+        produces embedded matrix multiplication."""
         cx1 = CX(wires=[0, 1], record=False)
         cx2 = CX(wires=[1, 2], record=False)
         result = cx1 @ cx2
@@ -1378,7 +1378,8 @@ class TestGateOperations:
 
     @pytest.mark.unittest
     def test_prod_function(self):
-        """Module-level prod function constructs generalized product of multiple operations."""
+        """Module-level prod function constructs generalized product 
+        (tensor or matrix) of multiple operations."""
         x = PauliX(wires=0, record=False)
         y = PauliY(wires=1, record=False)
         z = PauliZ(wires=0, record=False)
@@ -1570,7 +1571,6 @@ class TestMemory:
 
 
 class TestChunk:
-
     @pytest.mark.unittest
     @pytest.mark.limit_memory("1 GB")
     def test_memory_chunked_stays_bounded(self) -> None:
@@ -1769,7 +1769,6 @@ class TestChunk:
 
 
 class TestFidelity:
-
     @pytest.mark.unittest
     @pytest.mark.parametrize(
         "sv0,sv1,expected_val",
@@ -2175,9 +2174,9 @@ class TestPulse:
         """All expected envelope names are registered."""
         names = PulseEnvelope.available()
         for expected in ["gaussian", "square", "cosine", "drag", "sech"]:
-            assert (
-                expected in names
-            ), f"'{expected}' missing from PulseEnvelope.available()"
+            assert expected in names, (
+                f"'{expected}' missing from PulseEnvelope.available()"
+            )
 
     @pytest.mark.unittest
     def test_pulse_envelope_get_valid(self):
@@ -2190,15 +2189,15 @@ class TestPulse:
             if name != "general":
                 assert callable(info["fn"])
                 for gate in ["RX", "RY"]:
-                    assert (
-                        gate in info["defaults"]
-                    ), f"Missing default for gate '{gate}' in envelope '{name}'"
+                    assert gate in info["defaults"], (
+                        f"Missing default for gate '{gate}' in envelope '{name}'"
+                    )
             else:
                 assert info["fn"] is None
                 for gate in ["RZ", "CZ"]:
-                    assert (
-                        gate in info["defaults"]
-                    ), f"Missing default for gate '{gate}' in envelope '{name}'"
+                    assert gate in info["defaults"], (
+                        f"Missing default for gate '{gate}' in envelope '{name}'"
+                    )
 
     @pytest.mark.unittest
     def test_pulse_envelope_get_invalid(self):
@@ -2316,9 +2315,9 @@ class TestPulse:
                 expected_h = len(PulseInformation.RZ.params) + len(
                     PulseInformation.RY.params
                 )
-                assert (
-                    PulseInformation.H.size == expected_h
-                ), f"H param count wrong for envelope '{name}'"
+                assert PulseInformation.H.size == expected_h, (
+                    f"H param count wrong for envelope '{name}'"
+                )
         finally:
             PulseInformation.set_envelope(original)
 
@@ -2386,9 +2385,9 @@ class TestPulse:
             state_target = target_script.execute(type="state", args=(w,))
 
             f = jnp.abs(jnp.vdot(state_target, state_pulse)) ** 2
-            assert np.isclose(
-                f, 1.0, atol=1e-2
-            ), f"RZ fidelity too low for envelope '{envelope}': {f}"
+            assert np.isclose(f, 1.0, atol=1e-2), (
+                f"RZ fidelity too low for envelope '{envelope}': {f}"
+            )
         finally:
             PulseInformation.set_envelope(original)
 

--- a/tests/test_yaqsi.py
+++ b/tests/test_yaqsi.py
@@ -1382,12 +1382,12 @@ class TestGateOperations:
         x = PauliX(wires=0, record=False)
         y = PauliY(wires=1, record=False)
         z = PauliZ(wires=0, record=False)
-        
+
         result = prod(x, y, z)
         # X(0)*Z(0) \otimes Y(1)
         expected_xz = PauliX._matrix @ PauliZ._matrix
         expected = jnp.kron(expected_xz, PauliY._matrix)
-        
+
         assert jnp.allclose(result.matrix, expected, atol=1e-10)
         assert result.wires == [0, 1]
         assert result.name == "Prod(PauliX*PauliY*PauliZ)"
@@ -1398,11 +1398,11 @@ class TestGateOperations:
         x = PauliX(wires=0, record=False)
         y = PauliY(wires=1, record=False)
         z = PauliZ(wires=0, record=False)
-        
+
         result = x.prod(y, z)
         expected_xz = PauliX._matrix @ PauliZ._matrix
         expected = jnp.kron(expected_xz, PauliY._matrix)
-        
+
         assert jnp.allclose(result.matrix, expected, atol=1e-10)
         assert result.wires == [0, 1]
         assert result.name == "Prod(PauliX*PauliY*PauliZ)"
@@ -1410,15 +1410,16 @@ class TestGateOperations:
     @pytest.mark.unittest
     def test_prod_observable_execution(self):
         """prod operation can be used as an observable in Yaqsi."""
+
         def circuit():
             H(wires=0)
             H(wires=1)
-            
+
         script = Script(circuit, n_qubits=2)
         # <X0 X1> = 1.0 since state is |+>|+>
         obs_op = prod(PauliX(wires=0, record=False), PauliX(wires=1, record=False))
         res = script.execute(type="expval", obs=[obs_op])
-        
+
         assert jnp.allclose(res, jnp.array([1.0]), atol=1e-10)
 
     @pytest.mark.unittest

--- a/tests/test_yaqsi.py
+++ b/tests/test_yaqsi.py
@@ -34,6 +34,7 @@ from qml_essentials.operations import (
     Id,
     Hermitian,
     ParametrizedHamiltonian,
+    prod,
     # noise channels
     BitFlip,
     PhaseFlip,
@@ -1340,12 +1341,85 @@ class TestGateOperations:
         assert result.wires == [0, 1]
 
     @pytest.mark.unittest
-    def test_matmul_overlapping_wires_raises(self):
-        """Tensor product with overlapping wires must raise ValueError."""
+    def test_matmul_overlapping_wires(self):
+        """Tensor product with overlapping wires produces matrix multiplication."""
         x = PauliX(wires=0, record=False)
         z = PauliZ(wires=0, record=False)
-        with pytest.raises(ValueError, match="overlapping wires"):
-            _ = x @ z
+        result = x @ z
+        expected = PauliX._matrix @ PauliZ._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0]
+
+    @pytest.mark.unittest
+    def test_matmul_partial_overlap(self):
+        """Tensor product with partially overlapping wires produces embedded matrix multiplication."""
+        cx1 = CX(wires=[0, 1], record=False)
+        cx2 = CX(wires=[1, 2], record=False)
+        result = cx1 @ cx2
+
+        # CX1 embedded in [0, 1, 2] is CX ⊗ I
+        expected_cx1 = jnp.kron(CX._matrix, Id._matrix)
+        # CX2 embedded in [0, 1, 2] is I ⊗ CX
+        expected_cx2 = jnp.kron(Id._matrix, CX._matrix)
+
+        expected = expected_cx1 @ expected_cx2
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1, 2]
+
+    @pytest.mark.unittest
+    def test_mul_operation_composition(self):
+        """Multiplication (*) of two operations acts as composition."""
+        x = PauliX(wires=0, record=False)
+        z = PauliZ(wires=0, record=False)
+        result = x * z
+        expected = PauliX._matrix @ PauliZ._matrix
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0]
+
+    @pytest.mark.unittest
+    def test_prod_function(self):
+        """Module-level prod function constructs generalized product of multiple operations."""
+        x = PauliX(wires=0, record=False)
+        y = PauliY(wires=1, record=False)
+        z = PauliZ(wires=0, record=False)
+        
+        result = prod(x, y, z)
+        # X(0)*Z(0) \otimes Y(1)
+        expected_xz = PauliX._matrix @ PauliZ._matrix
+        expected = jnp.kron(expected_xz, PauliY._matrix)
+        
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1]
+        assert result.name == "Prod(PauliX*PauliY*PauliZ)"
+
+    @pytest.mark.unittest
+    def test_operation_prod_method(self):
+        """Operation.prod method constructs generalized product of operations."""
+        x = PauliX(wires=0, record=False)
+        y = PauliY(wires=1, record=False)
+        z = PauliZ(wires=0, record=False)
+        
+        result = x.prod(y, z)
+        expected_xz = PauliX._matrix @ PauliZ._matrix
+        expected = jnp.kron(expected_xz, PauliY._matrix)
+        
+        assert jnp.allclose(result.matrix, expected, atol=1e-10)
+        assert result.wires == [0, 1]
+        assert result.name == "Prod(PauliX*PauliY*PauliZ)"
+
+    @pytest.mark.unittest
+    def test_prod_observable_execution(self):
+        """prod operation can be used as an observable in Yaqsi."""
+        def circuit():
+            H(wires=0)
+            H(wires=1)
+            
+        script = Script(circuit, n_qubits=2)
+        # <X0 X1> = 1.0 since state is |+>|+>
+        obs_op = prod(PauliX(wires=0, record=False), PauliX(wires=1, record=False))
+        res = script.execute(type="expval", obs=[obs_op])
+        
+        assert jnp.allclose(res, jnp.array([1.0]), atol=1e-10)
 
     @pytest.mark.unittest
     def test_matmul_identity(self):


### PR DESCRIPTION
This PR aims to resolve #261 and #256 by
- unifying `__matmul__` and `__mul__` such that operations with either different or the same wires can be joined resulting either in matrix or tensor product
- introducing `prod`  as an operation- and module level function which allows joining an arbitrary number of operations either via `op1.prod(op2, op3, op4, ...)` or `prod(op1, op2, op3, op4, ...)`
- introducing tests accordingly