### PR TITLE
Fcc weighting

### DIFF
--- a/docs/coefficients.md
+++ b/docs/coefficients.md
@@ -215,7 +215,10 @@ fcc = FCC.get_fcc(
 ```
 Returns `0.1442` as already in Fig. 3a of aforementioned paper.
 
-Optionally, you can choose a different correlation `method` (currently "pearson" and "spearman" are supported).
+Optionally, you can choose a different correlation `method` (currently "pearson", "complex_pearson", and "spearman" are supported).
+The default "pearson" method preserves the existing behavior for complex coefficients by correlating stacked real and imaginary parts.
+The "complex_pearson" method computes a complex-valued Pearson coefficient via Hermitian normalized covariance, so the magnitude describes correlation strength and the angle describes the relative phase between coefficient vectors.
+When calculating the scalar FCC, `calculate_fcc` uses the magnitude of the fingerprint entries.
 Similar, other methods which require specifying `n_samples` (c.f. calculation of [expressibility](expressibility.md) and [entangling capability](entanglement.md)), methods in the `FCC` class take an optional parameter `scale` (defaults to `False`), which scales the number of samples depending on the number of qubits and the number of input features as $n_\text{samples} \cdot n_\text{params} \cdot 2^{n_\text{qubits}} \cdot n_\text{features}$.
 
 As described in our paper, the FCC is calculated as the mean of the Fourier fingerprint, which in turn can be obtained separately as follows:

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -1109,7 +1109,9 @@ class FCC:
 
         # perform weighting if requested
         fourier_fingerprint = (
-            cls._weighting(fourier_fingerprint) if weight else fourier_fingerprint
+            cls._weighting_mean(fourier_fingerprint, coeffs)
+            if weight
+            else fourier_fingerprint
         )
 
         if trim_redundant:
@@ -1439,13 +1441,13 @@ class FCC:
         return result
 
     @classmethod
-    def _weighting(cls, fourier_fingerprint: jnp.ndarray) -> jnp.ndarray:
+    def _weighting_linear(cls, fourier_fingerprint: jnp.ndarray) -> jnp.ndarray:
         """
         Performs weighting on the given correlation matrix.
         Here, low-frequent coefficients are weighted more heavily.
 
         Args:
-            correlation (jnp.ndarray): Correlation matrix
+            fourier_fingerprint (jnp.ndarray): Correlation matrix
         """
         # TODO: in Future iterations, this can be optimized by computing
         # on the trimmed matrix instead.
@@ -1491,7 +1493,39 @@ class FCC:
         weights_matrix = quadrant_to_matrix(weights)
 
         return fourier_fingerprint * weights_matrix
-        raise NotImplementedError("Weighting method is not implemented")
+
+    @classmethod
+    def _weighting_mean(
+        cls, fourier_fingerprint: jnp.ndarray, coeffs: jnp.ndarray
+    ) -> jnp.ndarray:
+        """
+        Performs weighting on the given correlation matrix.
+        Here, we use the product of the mean of the coefficients as weights.
+        This suppresses correlations where the mean of the coefficients is near zero.
+
+        Args:
+            fourier_fingerprint (jnp.ndarray): Correlation matrix
+            coeffs (jnp.ndarray): Fourier coefficients
+        """
+        # TODO: in Future iterations, this can be optimized by computing
+        # on the trimmed matrix instead.
+
+        assert fourier_fingerprint.shape[0] == fourier_fingerprint.shape[1], (
+            "Correlation matrix must be square."
+        )
+        assert len(coeffs.shape) >= 2, (
+            "Coefficient matrix must contain coefficient axes and a sample axis."
+        )
+
+        coefficient_means = jnp.abs(jnp.mean(coeffs, axis=-1))
+        coefficient_means = coefficient_means.T.reshape(-1)
+
+        assert fourier_fingerprint.shape[0] == coefficient_means.shape[0], (
+            "Correlation matrix size must match the number of Fourier coefficients."
+        )
+
+        weights_matrix = jnp.outer(coefficient_means, coefficient_means)
+        return fourier_fingerprint * weights_matrix
 
 
 class Datasets:

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -1030,7 +1030,8 @@ class FCC:
             n_samples (int): Number of samples to calculate average of coefficients
             random_key (Optional[random.PRNGKey]): JAX random key for parameter
                 initialization. If None, uses the model's internal random key.
-            method (Optional[str], optional): Correlation method. Defaults to "pearson".
+            method (Optional[str], optional): Correlation method. Supported values are
+                "pearson", "complex_pearson", and "spearman". Defaults to "pearson".
             scale (Optional[bool], optional): Whether to scale the number of samples.
                 Defaults to False.
             weight (Optional[bool], optional): Whether to weight the correlation matrix.
@@ -1082,7 +1083,8 @@ class FCC:
             n_samples (int): Number of samples to calculate average of coefficients
             random_key (Optional[random.PRNGKey]): JAX random key for parameter
                 initialization. If None, uses the model's internal random key.
-            method (Optional[str], optional): Correlation method. Defaults to "pearson".
+            method (Optional[str], optional): Correlation method. Supported values are
+                "pearson", "complex_pearson", and "spearman". Defaults to "pearson".
             scale (Optional[bool], optional): Whether to scale the number of samples.
                 Defaults to False.
             weight (Optional[bool], optional): Whether to weight the correlation matrix.
@@ -1231,7 +1233,7 @@ class FCC:
     def _correlate(cls, mat: jnp.ndarray, method: str = "pearson") -> jnp.ndarray:
         """
         Correlates two arrays using `method`.
-        Currently, `pearson` and `spearman` are supported.
+        Currently, `pearson`, `complex_pearson`, and `spearman` are supported.
 
         Args:
             mat (jnp.ndarray): Array of shape (N, K)
@@ -1256,14 +1258,81 @@ class FCC:
         if method == "pearson":
             result = cls._pearson(mat.reshape(mat.shape[0], -1))
             # result = cls._pearson(mat.reshape(mat.shape[-1], -1, order="F"))
+        elif method == "complex_pearson":
+            result = cls._complex_pearson(mat.reshape(mat.shape[0], -1))
         elif method == "spearman":
             result = cls._spearman(mat.reshape(mat.shape[0], -1))
             # result = cls._spearman(mat.reshape(mat.shape[-1], -1, order="F"))
         else:
             raise ValueError(
                 f"Unknown correlation method: {method}. \
-                             Must be 'pearson' or 'spearman'."
+                             Must be 'pearson', 'complex_pearson' or 'spearman'."
             )
+
+        return result
+
+    @classmethod
+    def _complex_pearson(
+        cls, mat: jnp.ndarray, cov: Optional[bool] = False, minp: Optional[int] = 1
+    ) -> jnp.ndarray:
+        """
+        Compute the complex Pearson correlation between columns of `mat`,
+        permitting missing values (NaN or ±Inf).
+
+        This uses the Hermitian normalized covariance
+        sum(conj(x_i - mean_i) * (x_j - mean_j)) /
+        sqrt(sum(abs(x_i - mean_i)**2) * sum(abs(x_j - mean_j)**2)).
+        Consequently, if column j is exp(1j * phi) times column i, then
+        abs(corr[i, j]) is 1 and angle(corr[i, j]) is phi.
+
+        Args:
+            mat : array_like, shape (N, K)
+                Input data.
+            cov : bool, optional
+                If True, return the sample covariance matrix instead of
+                correlation. Defaults to False.
+            minp : int, optional
+                Minimum number of paired observations required to form a correlation.
+                If the number of valid pairs for (i, j) is < minp, the result is NaN.
+
+        Returns:
+            corr : ndarray, shape (K, K)
+                Complex Pearson correlation matrix.
+        """
+        mat = jnp.asarray(mat)
+        real_dtype = jnp.asarray(mat.real).dtype
+
+        mask = jnp.isfinite(mat)
+        fmask = mask.astype(real_dtype)
+        safe = jnp.where(mask, mat, 0.0)
+
+        nobs = fmask.T @ fmask
+        nobs_safe = jnp.where(nobs > 0, nobs, 1.0)
+
+        sum_x = safe.T @ fmask
+        sum_y = fmask.T @ safe
+
+        masked = safe * fmask
+        sum_conj_xy = jnp.conj(masked).T @ masked
+
+        safe_abs_sq = jnp.abs(safe) ** 2
+        sum_abs_x2 = safe_abs_sq.T @ fmask
+        sum_abs_y2 = fmask.T @ safe_abs_sq
+
+        ssx = sum_abs_x2 - jnp.abs(sum_x) ** 2 / nobs_safe
+        ssy = sum_abs_y2 - jnp.abs(sum_y) ** 2 / nobs_safe
+        sxy = sum_conj_xy - (jnp.conj(sum_x) * sum_y) / nobs_safe
+
+        if cov:
+            denom = jnp.where(nobs > 1, nobs - 1, jnp.nan)
+            result = sxy / denom
+        else:
+            denom = jnp.sqrt(ssx * ssy)
+            result = jnp.where(denom > 0, sxy / denom, jnp.nan)
+            magnitude = jnp.abs(result)
+            result = jnp.where(magnitude > 1.0, result / magnitude, result)
+
+        result = jnp.where(nobs < minp, jnp.nan, result)
 
         return result
 

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -734,15 +734,20 @@ class TestFCC:
             output_qubit=-1,
             encoding=["RY"],
         )
-        fcc = FCC.get_fcc(
+        fcc_weight = FCC.get_fcc(
             model=model,
             n_samples=500,
             scale=True,
             weight=True,
         )
-        expected_fcc = 2.0e-8
-        assert jnp.isclose(fcc, expected_fcc, atol=5.0e-8), (
-            f"Wrong FCC for Circuit_19. Got {fcc}, expected {expected_fcc}."
+        fcc_no_weight = FCC.get_fcc(
+            model=model,
+            n_samples=500,
+            scale=True,
+            weight=False,
+        )
+        assert fcc_weight < fcc_no_weight, (
+            "Weighted FCC should be substantially smaller for degenerate circuits."
         )
 
 

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -552,6 +552,22 @@ class TestFCC:
         )
 
     @pytest.mark.unittest
+    def test_weighting_mean(self) -> None:
+        """Mean weighting should match the coefficient order used by correlation."""
+        fourier_fingerprint = jnp.arange(16, dtype=float).reshape(4, 4)
+        coeffs = jnp.array(
+            [
+                [[1.0, 3.0], [-2.0, 4.0]],
+                [[5.0, 7.0], [8.0, 10.0]],
+            ]
+        )
+
+        coefficient_means = jnp.abs(jnp.mean(coeffs, axis=-1)).T.reshape(-1)
+        expected = fourier_fingerprint * jnp.outer(coefficient_means, coefficient_means)
+
+        assert jnp.allclose(FCC._weighting_mean(fourier_fingerprint, coeffs), expected)
+
+    @pytest.mark.unittest
     @pytest.mark.parametrize(
         "circuit_type, expected_fcc",
         [
@@ -724,8 +740,9 @@ class TestFCC:
             scale=True,
             weight=True,
         )
-        assert jnp.isclose(fcc, 0.010, atol=5.0e-3), (
-            f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.010."
+        expected_fcc = 2.0e-8
+        assert jnp.isclose(fcc, expected_fcc, atol=5.0e-8), (
+            f"Wrong FCC for Circuit_19. Got {fcc}, expected {expected_fcc}."
         )
 
 

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -508,6 +508,61 @@ class TestFCC:
                 )
 
     @pytest.mark.unittest
+    def test_complex_pearson_correlation(self) -> None:
+        """Complex Pearson should match Hermitian normalized covariance."""
+        N = 1000
+        K = 5
+        seed = 314
+        rng = np.random.default_rng(seed)
+
+        coeffs = rng.normal(size=(N, K)) + 1j * rng.normal(size=(N, K))
+        coeffs[0, 1] = np.nan + 0.0j
+        coeffs[1, 2] = np.inf + 0.0j
+
+        complex_pearson = FCC._complex_pearson(jnp.array(coeffs))
+
+        for i in range(K):
+            for j in range(K):
+                valid = np.isfinite(coeffs[:, i]) & np.isfinite(coeffs[:, j])
+                x = coeffs[valid, i]
+                y = coeffs[valid, j]
+                x_centered = x - np.mean(x)
+                y_centered = y - np.mean(y)
+                denom = np.sqrt(
+                    np.sum(np.abs(x_centered) ** 2) * np.sum(np.abs(y_centered) ** 2)
+                )
+                reference = (
+                    np.sum(np.conj(x_centered) * y_centered) / denom
+                    if denom > 0
+                    else np.nan
+                )
+
+                assert jnp.isclose(complex_pearson[i, j], reference, atol=1.0e-5), (
+                    f"Complex Pearson mismatch at ({i},{j}): "
+                    f"got {complex_pearson[i, j]}, expected {reference}"
+                )
+
+    @pytest.mark.unittest
+    def test_complex_pearson_phase(self) -> None:
+        """Complex Pearson magnitude tracks correlation and angle tracks phase."""
+        N = 200
+        seed = 2718
+        phase = 0.37
+        rng = np.random.default_rng(seed)
+
+        x = rng.normal(size=N) + 1j * rng.normal(size=N)
+        y = np.exp(1j * phase) * x
+        coeffs = jnp.stack([jnp.array(x), jnp.array(y)], axis=1)
+
+        corr = FCC._complex_pearson(coeffs)
+        corr_from_method = FCC._correlate(coeffs, method="complex_pearson")
+
+        assert jnp.allclose(corr, corr_from_method, atol=1.0e-10)
+        assert jnp.isclose(jnp.abs(corr[0, 1]), 1.0, atol=1.0e-10)
+        assert jnp.isclose(jnp.angle(corr[0, 1]), phase, atol=1.0e-10)
+        assert jnp.isclose(jnp.angle(corr[1, 0]), -phase, atol=1.0e-10)
+
+    @pytest.mark.unittest
     def test_spearman_correlation_complex(self) -> None:
         """Spearman on complex input should match scipy on stacked real/imag."""
         N = 1000


### PR DESCRIPTION
This PR improves the FCC calculation by
- introducing a coefficient-mean-based weighting of the correlations in the Fourier Fingerprint (alongside the previous linear weighting approach, but using the "mean"-base method by default)
- introducing true complex correlation calculation (complex Pearson) in addition to the current approach where complex and real values were treated separately