### PR TITLE
Numerical cap n freqs

### DIFF
--- a/docs/coefficients.md
+++ b/docs/coefficients.md
@@ -240,5 +240,8 @@ This is implicitly done in `FCC.get_fourier_fingerprint` (and controlled using t
 - removing symmetries inside the correlation matrix (the Fourier fingerprint), e.g. $c_{0,1} = c_{1,0}$
 Note that `get_fcc` also (by default) trims down the fingerprint before calculating the actual FCC. 
 
+When `trim_redundant` is enabled, the frequencies returned alongside the fingerprint are a `(row_freqs, col_freqs)` tuple that labels the two (trimmed) matrix axes one-to-one, so they always match the shape of the returned correlation matrix.
+The optional `numerical_cap` argument (passed through to `get_spectrum`) prunes negligible Fourier modes: coefficients below the cap are zeroed and, for a single input feature, the corresponding frequencies are dropped from the spectrum. This keeps the returned coefficients, frequencies, and fingerprint axes consistent.
+
 Both `get_fcc` and `get_fourier_fingerprint` support a `weight` parameter, which can be used to weight the correlation matrix, such that high-frequency components receive a lower weight.
 Intuitively this adresses the issue, that low frequency components have a higher impact on the mean-squared error (c.f. App. D in our paper). 

--- a/docs/coefficients.md
+++ b/docs/coefficients.md
@@ -241,7 +241,7 @@ This is implicitly done in `FCC.get_fourier_fingerprint` (and controlled using t
 Note that `get_fcc` also (by default) trims down the fingerprint before calculating the actual FCC. 
 
 When `trim_redundant` is enabled, the frequencies returned alongside the fingerprint are a `(row_freqs, col_freqs)` tuple that labels the two (trimmed) matrix axes one-to-one, so they always match the shape of the returned correlation matrix.
-The optional `numerical_cap` argument (passed through to `get_spectrum`) prunes negligible Fourier modes: coefficients below the cap are zeroed and, for a single input feature, the corresponding frequencies are dropped from the spectrum. This keeps the returned coefficients, frequencies, and fingerprint axes consistent.
+The optional `numerical_cap` argument (passed through to `get_spectrum`) prunes negligible Fourier modes: coefficients below the cap are zeroed and, for a single input feature, the corresponding frequencies are dropped from the spectrum. 
 
 Both `get_fcc` and `get_fourier_fingerprint` support a `weight` parameter, which can be used to weight the correlation matrix, such that high-frequency components receive a lower weight.
 Intuitively this adresses the issue, that low frequency components have a higher impact on the mean-squared error (c.f. App. D in our paper). 

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -1289,20 +1289,21 @@ class FCC:
 
         Args:
             freqs (jnp.ndarray): Either a 1-D vector (single input feature)
-                or a list of per-axis frequency vectors (multi-dim input).
+                or a ``(n_input_feat, K)`` stack / list of per-axis frequency
+                vectors (multi-dim input).
 
         Returns:
             jnp.ndarray: 1-D frequency vector (single input feature) or a
                 ``(N, n_input_feat)`` array of per-coefficient frequency
                 tuples (multi-dim input).
         """
-        if isinstance(freqs, list):
-            fa = jnp.asarray(freqs)  # (n_input_feat, K)
-            grids = jnp.meshgrid(
-                *[fa[i] for i in range(fa.shape[0])], indexing="ij"
-            )
-            return jnp.stack(grids, axis=-1).reshape(-1, fa.shape[0])
-        return jnp.asarray(freqs)
+        fa = jnp.asarray(freqs)
+        if fa.ndim == 1:
+            return fa
+        # Multi-dim: per-axis vectors -> flat grid of frequency tuples in the
+        # same C-order used by `_calculate_mask` and the coefficient reshape.
+        grids = jnp.meshgrid(*[fa[i] for i in range(fa.shape[0])], indexing="ij")
+        return jnp.stack(grids, axis=-1).reshape(-1, fa.shape[0])
 
     @classmethod
     def _calculate_coefficients(

--- a/qml_essentials/coefficients.py
+++ b/qml_essentials/coefficients.py
@@ -53,6 +53,9 @@ class Coefficients:
             trim (bool): Whether to remove the Nyquist frequency if spectrum is even.
                 Default is False.
             numerical_cap (Optional[float]): Numerical cap for the coefficients.
+                If positive, coefficients with magnitude below the cap are
+                zeroed and, for a single input feature, frequencies that
+                vanish entirely are removed from both `coeffs` and `freqs`.
             kwargs (Any): Additional keyword arguments for the model function.
 
         Returns:
@@ -87,6 +90,20 @@ class Coefficients:
                 jnp.zeros_like(coeffs),
                 coeffs,
             )
+
+            # Drop frequencies whose coefficients vanish entirely after
+            # capping, so the returned spectrum reflects only the surviving
+            # frequencies. Well-defined only for a single (1-D) frequency
+            # axis; for multi-dim input the rectangular grid is left intact.
+            if model.n_input_feat == 1:
+                if coeffs.ndim == 1:
+                    surviving = coeffs != 0
+                else:
+                    surviving = jnp.any(
+                        coeffs != 0, axis=tuple(range(1, coeffs.ndim))
+                    )
+                coeffs = coeffs[surviving]
+                freqs = [freqs[0][surviving]]
 
         if len(freqs) == 1:
             freqs = freqs[0]
@@ -1118,8 +1135,11 @@ class FCC:
             **kwargs: Additional keyword arguments for the model function.
 
         Returns:
-            Tuple[jnp.ndarray, jnp.ndarray]: The fourier fingerprint
-            and the frequency indices
+            Tuple[jnp.ndarray, jnp.ndarray]: The fourier fingerprint and the
+            corresponding frequency indices. If `trim_redundant` is True the
+            frequencies are returned as a `(row_freqs, col_freqs)` tuple that
+            labels the two (redundancy-trimmed) matrix axes; otherwise the
+            full frequency vector is returned.
         """
         _, coeffs, freqs = cls._calculate_coefficients(
             model, n_samples, random_key, scale, **kwargs
@@ -1128,6 +1148,7 @@ class FCC:
         # Memory-efficient fast path
         if trim_redundant and not weight:
             pos_idx = cls._calculate_mask(freqs)
+            pos_freqs = cls._flat_frequencies(freqs)[pos_idx]
 
             # Flatten all frequency axes; the last axis is the sample
             # axis. `_calculate_mask` returns flat indices in C order,
@@ -1152,7 +1173,7 @@ class FCC:
             col_mask = jnp.any(jnp.isfinite(fourier_fingerprint), axis=0)
             fourier_fingerprint = fourier_fingerprint[row_mask][:, col_mask]
 
-            return fourier_fingerprint, freqs
+            return fourier_fingerprint, (pos_freqs[row_mask], pos_freqs[col_mask])
 
         fourier_fingerprint = cls._correlate(coeffs.transpose(), method=method)
 
@@ -1169,6 +1190,7 @@ class FCC:
 
         if trim_redundant:
             pos_idx = cls._calculate_mask(freqs)
+            pos_freqs = cls._flat_frequencies(freqs)[pos_idx]
 
             # restrict to the positive-frequency sub-block (M x M with
             # M = number of non-negative flat-frequencies) instead of
@@ -1186,6 +1208,8 @@ class FCC:
             col_mask = jnp.any(jnp.isfinite(fourier_fingerprint), axis=0)
 
             fourier_fingerprint = fourier_fingerprint[row_mask][:, col_mask]
+
+            return fourier_fingerprint, (pos_freqs[row_mask], pos_freqs[col_mask])
 
         return fourier_fingerprint, freqs
 
@@ -1255,6 +1279,30 @@ class FCC:
             pos_flat = nd_pos.flatten()
 
         return jnp.where(pos_flat)[0]
+
+    @classmethod
+    def _flat_frequencies(cls, freqs: jnp.ndarray) -> jnp.ndarray:
+        """
+        Build the per-coefficient flat frequency labels in the same
+        C-order used to flatten the coefficient/correlation pipeline, so
+        they can be indexed by the flat indices from `_calculate_mask`.
+
+        Args:
+            freqs (jnp.ndarray): Either a 1-D vector (single input feature)
+                or a list of per-axis frequency vectors (multi-dim input).
+
+        Returns:
+            jnp.ndarray: 1-D frequency vector (single input feature) or a
+                ``(N, n_input_feat)`` array of per-coefficient frequency
+                tuples (multi-dim input).
+        """
+        if isinstance(freqs, list):
+            fa = jnp.asarray(freqs)  # (n_input_feat, K)
+            grids = jnp.meshgrid(
+                *[fa[i] for i in range(fa.shape[0])], indexing="ij"
+            )
+            return jnp.stack(grids, axis=-1).reshape(-1, fa.shape[0])
+        return jnp.asarray(freqs)
 
     @classmethod
     def _calculate_coefficients(

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -317,6 +317,58 @@ class TestCoefficients:
         coeffs, _ = Coefficients.get_spectrum(model, shift=True)
         _ = Coefficients.get_psd(coeffs)
 
+    @pytest.mark.unittest
+    def test_numerical_cap_trims_spectrum(self) -> None:
+        """
+        With `numerical_cap > 0`, frequencies whose coefficients vanish
+        entirely after capping must be removed from both `coeffs` and
+        `freqs`, so the returned spectrum stays self-consistent.
+        """
+        model = Model(
+            n_qubits=3,
+            n_layers=3,
+            circuit_type="Strongly_Entangling",
+            encoding=Encoding("hamming", "RZ"),
+            output_qubit=-1,
+        )
+        model.initialize_params(jax.random.key(1000), repeat=20)
+
+        coeffs_full, freqs_full = Coefficients.get_spectrum(
+            model, shift=True, trim=True, numerical_cap=-1
+        )
+
+        # per-frequency maximum magnitude over the sample axis; a frequency
+        # is dropped iff this maximum is below the cap
+        sample_axes = tuple(range(1, coeffs_full.ndim))
+        per_freq_max = jnp.max(jnp.abs(coeffs_full), axis=sample_axes)
+        cap = float(jnp.median(per_freq_max))
+
+        coeffs_cap, freqs_cap = Coefficients.get_spectrum(
+            model, shift=True, trim=True, numerical_cap=cap
+        )
+
+        # coeffs and freqs stay consistent
+        assert coeffs_cap.shape[0] == freqs_cap.shape[0], (
+            "Capped coeffs and freqs must have matching length."
+        )
+        # strictly fewer frequencies survive
+        assert freqs_cap.shape[0] < freqs_full.shape[0], (
+            "Cap must remove at least one frequency."
+        )
+        # surviving frequencies are exactly those above the cap
+        expected = freqs_full[per_freq_max >= cap]
+        assert jnp.array_equal(jnp.sort(freqs_cap), jnp.sort(expected)), (
+            "Surviving frequencies must match the above-cap selection."
+        )
+        # no surviving coefficient vector is all-zero
+        assert jnp.all(
+            jnp.any(coeffs_cap != 0, axis=tuple(range(1, coeffs_cap.ndim)))
+        ), "Surviving coefficients must contain a non-zero entry."
+        # the spectrum stays symmetric around zero
+        assert jnp.array_equal(jnp.sort(freqs_cap), jnp.sort(-freqs_cap)), (
+            "Surviving frequencies must remain symmetric around zero."
+        )
+
 
 class TestFourierTree:
     """Tests for analytical Fourier tree coefficient computation."""
@@ -768,6 +820,42 @@ class TestFCC:
         )
         assert jnp.isclose(fcc, 0.016, atol=2.0e-3), (
             f"Wrong FCC for Circuit_19. Got {fcc}, expected 0.020."
+        )
+
+    @pytest.mark.unittest
+    @pytest.mark.parametrize("weight", [False, True], ids=["fast", "weighted"])
+    def test_fingerprint_freqs_match_matrix(self, weight) -> None:
+        """
+        With `numerical_cap`, the frequencies returned by
+        `get_fourier_fingerprint` must label the trimmed matrix axes 1:1,
+        i.e. a `(row_freqs, col_freqs)` tuple matching the matrix shape.
+        """
+        model = Model(
+            n_qubits=3,
+            n_layers=3,
+            circuit_type="Strongly_Entangling",
+            encoding=Encoding("hamming", "RZ"),
+            output_qubit=-1,
+        )
+        matrix, freqs = FCC.get_fourier_fingerprint(
+            model=model,
+            n_samples=50,
+            random_key=jax.random.key(1000),
+            weight=weight,
+            numerical_cap=1e-10,
+        )
+
+        assert isinstance(freqs, tuple) and len(freqs) == 2, (
+            "Trimmed fingerprint must return a (row_freqs, col_freqs) tuple."
+        )
+        row_freqs, col_freqs = freqs
+        assert row_freqs.shape[0] == matrix.shape[0], (
+            f"Row freqs ({row_freqs.shape[0]}) must match matrix rows "
+            f"({matrix.shape[0]})."
+        )
+        assert col_freqs.shape[0] == matrix.shape[1], (
+            f"Col freqs ({col_freqs.shape[0]}) must match matrix cols "
+            f"({matrix.shape[1]})."
         )
 
     @pytest.mark.unittest

--- a/tests/test_coefficients.py
+++ b/tests/test_coefficients.py
@@ -859,6 +859,34 @@ class TestFCC:
         )
 
     @pytest.mark.unittest
+    def test_fingerprint_freqs_match_matrix_2d(self) -> None:
+        """
+        The matrix-axis frequency alignment also holds for multi-dimensional
+        input, where each axis label is a per-coefficient frequency tuple.
+        """
+        model = Model(
+            n_qubits=3,
+            n_layers=2,
+            circuit_type="Strongly_Entangling",
+            encoding=["RX", "RY"],
+            output_qubit=-1,
+        )
+        matrix, freqs = FCC.get_fourier_fingerprint(
+            model=model,
+            n_samples=50,
+            random_key=jax.random.key(1000),
+            numerical_cap=1e-10,
+        )
+
+        assert isinstance(freqs, tuple) and len(freqs) == 2
+        row_freqs, col_freqs = freqs
+        assert row_freqs.shape[0] == matrix.shape[0]
+        assert col_freqs.shape[0] == matrix.shape[1]
+        # each axis label is a (f_x, f_y) frequency tuple
+        assert row_freqs.shape[1] == model.n_input_feat
+        assert col_freqs.shape[1] == model.n_input_feat
+
+    @pytest.mark.unittest
     def test_weighting(self) -> None:
         """
         This test replicates the results obtained for the FCC


### PR DESCRIPTION
This PR resolves #274 and closes #255 (and also closes #195 as stale) by making the frequencies vector returned by `get_fourier_fingerprint` aware of the frequencies actually present after applying `numerical_cap`. Used following code to evaluate: 

```python
n_points = 1024
numerical_cap = 1e-10

model = Model(
    n_qubits=5,
    n_layers=10,
    circuit_type="Strongly_Entangling",
    encoding=Encoding(strategy="hamming", gates="RZ")
)

fingerprint_matrix, fingerprint_freqs = FCC.get_fourier_fingerprint(
    model=copy(model),
    n_samples=n_points,
    scale = False,
    numerical_cap = numerical_cap
)

print(fingerprint_freqs)
print(fingerprint_matrix.shape)
```

which now yields following output:

```
(Array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12., 13.,
       14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26.,
       27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38., 39.,
       40., 41., 42.], dtype=float64), Array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12.,
       13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
       26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.,
       39., 40., 41.], dtype=float64))
(42, 42)
```

thus trimming the last couple of frequencies as they are not present in the model (or below `numerical_cap`).